### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,8 @@ jobs:
 
   security-audit:
     name: Security Audit
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/bostdiek/PantryPilot/security/code-scanning/6](https://github.com/bostdiek/PantryPilot/security/code-scanning/6)

To fix the problem, add a `permissions` block to the `security-audit` job in `.github/workflows/ci.yml` specifying the least required privileges, which in this case is `contents: read`. This will ensure that the generated GitHub token only has permission to read repository contents, aligning with the principle of least privilege. The change should be made by inserting the block directly under the `name: Security Audit` key of the job definition. No changes to existing steps, logic, or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
