### PR TITLE
feat 67: Minimal JWT Auth + Argon2 password hashing + protected routes

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -43,6 +43,40 @@
                 "reveal": "always",
                 "panel": "new"
             }
+        },
+        {
+            "label": "Test: Run Pattern (-k)",
+            "type": "shell",
+            "command": "cd ${workspaceFolder}/apps/backend && uv run pytest -k \"${input:pytestPattern}\" -q",
+            "group": "test",
+            "presentation": {"reveal": "always", "panel": "dedicated"}
+        },
+        {
+            "label": "Test: Run Single Node",
+            "type": "shell",
+            "command": "cd ${workspaceFolder}/apps/backend && uv run pytest ${input:pytestNode} -q",
+            "group": "test",
+            "presentation": {"reveal": "always", "panel": "dedicated"}
+        },
+        {
+            "label": "Test: Rerun Last Failures",
+            "type": "shell",
+            "command": "cd ${workspaceFolder}/apps/backend && uv run pytest --last-failed -q",
+            "group": "test",
+            "presentation": {"reveal": "always", "panel": "dedicated"}
+        }
+    ]
+    ,
+    "inputs": [
+        {
+            "id": "pytestPattern",
+            "type": "promptString",
+            "description": "Pytest -k expression (pattern)"
+        },
+        {
+            "id": "pytestNode",
+            "type": "promptString",
+            "description": "Test node path (e.g. tests/test_auth.py::test_login_success)"
         }
     ]
 }

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,15 @@ test-coverage:
 	# Run backend tests with coverage
 	cd apps/backend && uv run pytest --cov=src --cov-report=term --cov-report=html
 
+# Create a development user in the backend DB (idempotent). Run inside backend container.
+.PHONY: create-dev-user
+create-dev-user:
+	@echo "Creating dev user in backend DB..."
+	# The backend container mounts the backend source at /app, so the script
+	# is available at /app/scripts/create_dev_user.py inside the container.
+	docker compose --env-file $(ENV_FILE) $(COMPOSE_FILES) exec -T backend sh -lc "uv run python /app/scripts/create_dev_user.py"
+
+
 # Convenience targets
 check: lint type-check check-migrations
 	# Run all code quality checks

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -12,6 +12,10 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "asyncpg>=0.29.0",
     "greenlet>=3.0.0",
+    "python-jose[cryptography]>=3.5.0",
+    "argon2-cffi>=25.1.0",
+    "pydantic-settings>=2.10.1",
+    "types-python-jose>=3.5.0.20250531",
 ]
 
 [dependency-groups]

--- a/apps/backend/scripts/create_dev_user.py
+++ b/apps/backend/scripts/create_dev_user.py
@@ -1,0 +1,56 @@
+"""Idempotent dev user creation script.
+
+Run inside the backend container or locally with the repo's environment loaded.
+
+Usage (local):
+  uv run python apps/backend/scripts/create_dev_user.py
+
+Usage (Makefile target runs it in container):
+  make create-dev-user
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from uuid import uuid4
+
+from sqlalchemy import select
+
+from core.security import get_password_hash
+from dependencies.db import AsyncSessionLocal
+from models.users import User
+
+
+DEV_USERNAME = os.getenv("DEV_USER_USERNAME", "dev")
+DEV_EMAIL = os.getenv("DEV_USER_EMAIL", "dev@example.com")
+DEV_PASSWORD = os.getenv("DEV_USER_PASSWORD", "devdevdev")
+
+
+async def main() -> None:
+    async with AsyncSessionLocal() as session:
+        # Check for existing user by username or email
+        stmt = (
+            select(User.id)
+            .where((User.username == DEV_USERNAME) | (User.email == DEV_EMAIL))
+            .limit(1)
+        )
+        existing_id = await session.scalar(stmt)
+        if existing_id is not None:
+            print(f"Dev user already exists (id={existing_id}) - skipping")
+            return
+
+        hashed = get_password_hash(DEV_PASSWORD)
+        user = User(
+            id=uuid4(),
+            username=DEV_USERNAME,
+            email=DEV_EMAIL,
+            hashed_password=hashed,
+        )
+        session.add(user)
+        await session.commit()
+        print(f"Created dev user: {DEV_USERNAME} <{DEV_EMAIL}>")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/backend/src/alembic/versions/20250902_04_tighten_users_username_and_names.py
+++ b/apps/backend/src/alembic/versions/20250902_04_tighten_users_username_and_names.py
@@ -1,0 +1,86 @@
+"""tighten users: username/name lengths and username check
+
+Revision ID: 20250902_04
+Revises: 20250827_03
+Create Date: 2025-09-02
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "20250902_04"
+down_revision = "20250827_03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Note: shrinking lengths can fail if existing data exceeds new limits.
+    op.alter_column(
+        "users",
+        "username",
+        type_=sa.String(length=50),
+        existing_type=sa.String(length=255),
+        existing_nullable=False,
+        existing_server_default=None,
+    )
+    op.alter_column(
+        "users",
+        "first_name",
+        type_=sa.String(length=50),
+        existing_type=sa.String(length=255),
+        existing_nullable=True,
+        existing_server_default=None,
+    )
+    op.alter_column(
+        "users",
+        "last_name",
+        type_=sa.String(length=50),
+        existing_type=sa.String(length=255),
+        existing_nullable=True,
+        existing_server_default=None,
+    )
+
+    # Enforce username length at DB level (3–50)
+    op.create_check_constraint(
+        "ck_users_username_len",
+        "users",
+        "length(username) BETWEEN 3 AND 50",
+    )
+
+
+def downgrade() -> None:
+    # Drop the username length check
+    op.drop_constraint("ck_users_username_len", "users", type_="check")
+
+    # Revert lengths
+    op.alter_column(
+        "users",
+        "last_name",
+        type_=sa.String(length=255),
+        existing_type=sa.String(length=50),
+        existing_nullable=True,
+        existing_server_default=None,
+    )
+    op.alter_column(
+        "users",
+        "first_name",
+        type_=sa.String(length=255),
+        existing_type=sa.String(length=50),
+        existing_nullable=True,
+        existing_server_default=None,
+    )
+    op.alter_column(
+        "users",
+        "username",
+        type_=sa.String(length=255),
+        existing_type=sa.String(length=50),
+        existing_nullable=False,
+        existing_server_default=None,
+    )

--- a/apps/backend/src/api/v1/api.py
+++ b/apps/backend/src/api/v1/api.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+
+from dependencies.auth import get_current_user
 
 from .auth import router as auth_router
 from .health import router as health_router
@@ -6,11 +8,18 @@ from .mealplans import meals_router, router as mealplans_router
 from .recipes import router as recipes_router
 
 
+# Public API router (health, auth)
 api_router = APIRouter()
 
-# Include all v1 routers
+# Include public routers
 api_router.include_router(health_router, tags=["health"])
-api_router.include_router(recipes_router)
-api_router.include_router(mealplans_router)
-api_router.include_router(meals_router)
-api_router.include_router(auth_router, prefix="/auth")
+api_router.include_router(auth_router)
+
+
+# Protected routers: include with a router-level dependency so all routes
+# require authentication by default. Use get_current_user dependency to
+# surface the OAuth2 security scheme in OpenAPI as well.
+protected_deps = [Depends(get_current_user)]
+api_router.include_router(recipes_router, dependencies=protected_deps)
+api_router.include_router(mealplans_router, dependencies=protected_deps)
+api_router.include_router(meals_router, dependencies=protected_deps)

--- a/apps/backend/src/api/v1/api.py
+++ b/apps/backend/src/api/v1/api.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from .auth import router as auth_router
 from .health import router as health_router
 from .mealplans import meals_router, router as mealplans_router
 from .recipes import router as recipes_router
@@ -12,3 +13,4 @@ api_router.include_router(health_router, tags=["health"])
 api_router.include_router(recipes_router)
 api_router.include_router(mealplans_router)
 api_router.include_router(meals_router)
+api_router.include_router(auth_router, prefix="/auth")

--- a/apps/backend/src/api/v1/auth.py
+++ b/apps/backend/src/api/v1/auth.py
@@ -1,0 +1,35 @@
+"""apps/backend/src/api/v1/auth.py: Auth (login) API routes."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+
+from core.security import create_access_token, verify_password
+from crud.user import get_user_by_username
+from dependencies.db import DbSession
+from schemas.auth import Token
+
+
+router = APIRouter(prefix="", tags=["auth"])
+
+PasswordForm = Annotated[OAuth2PasswordRequestForm, Depends()]
+
+
+@router.post("/login", response_model=Token)
+async def login(form_data: PasswordForm, db: DbSession) -> Token:
+    """
+    OAuth2-compatible token login, get an access token for future requests.
+
+    - **username**: The user's username
+    - **password**: The user's password
+    """
+    user = await get_user_by_username(db=db, username=form_data.username)
+    if not user or not verify_password(form_data.password, user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    access_token = create_access_token(data={"sub": str(user.id)})
+    return Token(access_token=access_token, token_type="bearer")

--- a/apps/backend/src/api/v1/auth.py
+++ b/apps/backend/src/api/v1/auth.py
@@ -11,7 +11,7 @@ from dependencies.db import DbSession
 from schemas.auth import Token
 
 
-router = APIRouter(prefix="", tags=["auth"])
+router = APIRouter(prefix="/auth", tags=["auth"])
 
 PasswordForm = Annotated[OAuth2PasswordRequestForm, Depends()]
 

--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -80,4 +80,7 @@ def get_settings() -> Settings:
     else:
         env_file = ".env.prod"
     # pydantic-settings supports _env_file at runtime; mypy doesn't type it.
+    # Provide safe fallbacks for tests if env file is absent.
+    if not os.path.exists(env_file):  # pragma: no cover - defensive
+        os.environ.setdefault("SECRET_KEY", "dev-test-secret")
     return Settings(_env_file=env_file)  # type: ignore[call-arg]

--- a/apps/backend/src/core/exceptions.py
+++ b/apps/backend/src/core/exceptions.py
@@ -1,0 +1,16 @@
+class DomainError(Exception):
+    """Base class for domain-specific errors."""
+
+    pass
+
+
+class DuplicateUserError(DomainError):
+    """Exception raised when attempting to create a user that already exists."""
+
+    pass
+
+
+class UserNotFoundError(DomainError):
+    """Exception raised when a user is not found in the database."""
+
+    pass

--- a/apps/backend/src/core/security.py
+++ b/apps/backend/src/core/security.py
@@ -1,0 +1,80 @@
+from datetime import UTC, datetime, timedelta
+
+from argon2 import PasswordHasher
+from fastapi import HTTPException, status
+from jose import JWTError, jwt
+
+from core.config import get_settings
+from schemas.auth import TokenData
+
+
+settings = get_settings()
+
+# Reuse a single PasswordHasher instance (Argon2id by default)
+_password_hasher = PasswordHasher()
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+    """Encodes a JWT with `sub` (subject) and expiry"""
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.now(UTC) + expires_delta
+    else:
+        expire = datetime.now(UTC) + timedelta(
+            minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
+        )
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(
+        to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM
+    )
+    return encoded_jwt
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    """Verify a plaintext password against an Argon2 hash.
+
+    Do NOT hash the plaintext and compare strings — Argon2 uses a random salt,
+    so re-hashing the same password yields a different hash. Always use verify().
+    """
+    try:
+        return _password_hasher.verify(hashed, plain)
+    except Exception:
+        return False
+
+
+def get_password_hash(password: str) -> str:
+    """Hash a plaintext password using Argon2id."""
+    return _password_hasher.hash(password)
+
+
+def decode_token(token: str) -> TokenData:
+    """Decode and validate a JWT, returning TokenData or raising 401.
+
+    Expects a `sub` claim (user identifier). Also supports optional `scopes`.
+    """
+    try:
+        payload = jwt.decode(
+            token,
+            settings.SECRET_KEY,
+            algorithms=[settings.ALGORITHM],
+            options={"verify_aud": False},
+        )
+    except JWTError as err:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from err
+
+    sub = payload.get("sub")
+    scopes = payload.get("scopes", [])
+    if sub is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token missing subject",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return TokenData(
+        sub=str(sub),
+        scopes=list(scopes) if isinstance(scopes, list) else [],
+    )

--- a/apps/backend/src/crud/user.py
+++ b/apps/backend/src/crud/user.py
@@ -1,0 +1,57 @@
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.exceptions import DuplicateUserError
+from models.users import User
+
+
+async def get_user_by_email(db: AsyncSession, email: str) -> User | None:
+    """Get a user by their email address."""
+    statement = select(User).where(User.email == email)
+    result = await db.execute(statement)
+    return result.scalar_one_or_none()
+
+
+async def get_user_by_username(db: AsyncSession, username: str) -> User | None:
+    """Get a user by their username."""
+    statement = select(User).where(User.username == username)
+    result = await db.execute(statement)
+    return result.scalar_one_or_none()
+
+
+async def get_user_by_id(db: AsyncSession, user_id: UUID) -> User | None:
+    """Get a user by their ID."""
+    statement = select(User).where(User.id == user_id)
+    result = await db.execute(statement)
+    return result.scalar_one_or_none()
+
+
+async def create_user(
+    db: AsyncSession,
+    email: str,
+    username: str,
+    hashed_password: str,
+    first_name: str | None = None,
+    last_name: str | None = None,
+) -> User:
+    """Create a new user."""
+    new_user = User(
+        email=email,
+        username=username,
+        hashed_password=hashed_password,
+        first_name=first_name,
+        last_name=last_name,
+    )
+    try:
+        db.add(new_user)
+        await db.commit()
+    except IntegrityError as exc:
+        # Duplicate email/username, ensure transaction is clean before re-raising
+        await db.rollback()
+        raise DuplicateUserError from exc
+    # Refresh after successful commit to load any DB defaults
+    await db.refresh(new_user)
+    return new_user

--- a/apps/backend/src/dependencies/auth.py
+++ b/apps/backend/src/dependencies/auth.py
@@ -1,0 +1,46 @@
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+
+from core.security import decode_token
+from crud.user import get_user_by_id
+from dependencies.db import DbSession
+from models.users import User
+
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
+
+
+async def get_current_user(
+    db: DbSession,
+    token: Annotated[str, Depends(oauth2_scheme)],
+) -> User:
+    # decode_token already raises 401 with WWW-Authenticate on invalid/expired tokens
+    token_data = decode_token(token)
+
+    if not token_data.sub:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        user_id = UUID(token_data.sub)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+    user = await get_user_by_id(db, user_id)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return user

--- a/apps/backend/src/dependencies/auth.py
+++ b/apps/backend/src/dependencies/auth.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import logging
 from typing import Annotated
 from uuid import UUID
 
@@ -10,37 +13,71 @@ from dependencies.db import DbSession
 from models.users import User
 
 
+# --------------------------------------------------------------------------- #
+# Common constants / helpers
+# --------------------------------------------------------------------------- #
+LOGGER = logging.getLogger(__name__)
+BEARER = "Bearer"
+
+
+def unauthorized(detail: str = "Could not validate credentials") -> HTTPException:
+    """Return the canonical 401 response."""
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=detail,
+        headers={"WWW-Authenticate": BEARER},
+    )
+
+
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
 
 
+# --------------------------------------------------------------------------- #
+# The dependency
+# --------------------------------------------------------------------------- #
 async def get_current_user(
     db: DbSession,
     token: Annotated[str, Depends(oauth2_scheme)],
 ) -> User:
-    # decode_token already raises 401 with WWW-Authenticate on invalid/expired tokens
-    token_data = decode_token(token)
+    """
+    Resolve the currently authenticated user from a JWT.
 
-    if not token_data.sub:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Could not validate credentials",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+    Raises
+    ------
+    HTTPException(401)
+        If the token is missing, malformed, expired, or the user does not exist.
+    """
 
+    # Decode the JWT – any error already triggers a 401
     try:
-        user_id = UUID(token_data.sub)
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Could not validate credentials",
-            headers={"WWW-Authenticate": "Bearer"},
-        ) from exc
+        token_data = decode_token(token)
+    except Exception as exc:  # pragma: no cover
+        LOGGER.debug("Token decoding failed", exc_info=exc)
+        raise unauthorized() from exc
 
-    user = await get_user_by_id(db, user_id)
+    # Validate the subject claim
+    sub = getattr(token_data, "sub", None)
+    if not sub:
+        LOGGER.debug("Token missing 'sub' claim")
+        raise unauthorized()
+
+    # Convert `sub` to a UUID
+    try:
+        user_id = UUID(sub)
+    except ValueError as exc:
+        LOGGER.debug("Token 'sub' is not a valid UUID", exc_info=exc)
+        raise unauthorized() from exc
+
+    # Pull the user from the DB
+    try:
+        user = await get_user_by_id(db, user_id)
+    except Exception as exc:  # pragma: no cover
+        LOGGER.error("DB lookup failed", exc_info=exc)
+        # Let FastAPI surface a 500 – or raise a custom 503 if you prefer
+        raise
+
     if user is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Could not validate credentials",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        LOGGER.debug("User not found for sub=%s", sub)
+        raise unauthorized()
+
     return user

--- a/apps/backend/src/models/users.py
+++ b/apps/backend/src/models/users.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import UUID, Column, DateTime, String, func
+from sqlalchemy import UUID, CheckConstraint, Column, DateTime, String, func
 from sqlalchemy.orm import relationship
 
 from .base import Base
@@ -8,13 +8,20 @@ from .base import Base
 
 class User(Base):
     __tablename__ = "users"
+    __table_args__ = (
+        # Match schemas: username length 3–50
+        # Use length(), which is SQLite/Postgres compatible
+        CheckConstraint(
+            "length(username) BETWEEN 3 AND 50", name="ck_users_username_len"
+        ),
+    )
 
     id = Column(UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4)
-    username = Column(String(255), unique=True, nullable=False, index=True)
+    username = Column(String(50), unique=True, nullable=False, index=True)
     email = Column(String(255), unique=True, nullable=False, index=True)
     hashed_password = Column(String(255), nullable=False)
-    first_name = Column(String(255))
-    last_name = Column(String(255))
+    first_name = Column(String(50))
+    last_name = Column(String(50))
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now())
 

--- a/apps/backend/src/models/users.py
+++ b/apps/backend/src/models/users.py
@@ -1,7 +1,15 @@
-import uuid
+from __future__ import annotations
 
-from sqlalchemy import UUID, CheckConstraint, Column, DateTime, String, func
-from sqlalchemy.orm import relationship
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import UUID, CheckConstraint, DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+
+if TYPE_CHECKING:  # pragma: no cover - only for type checking
+    from .meal_history import Meal
 
 from .base import Base
 
@@ -16,14 +24,24 @@ class User(Base):
         ),
     )
 
-    id = Column(UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4)
-    username = Column(String(50), unique=True, nullable=False, index=True)
-    email = Column(String(255), unique=True, nullable=False, index=True)
-    hashed_password = Column(String(255), nullable=False)
-    first_name = Column(String(50))
-    last_name = Column(String(50))
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now())
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4
+    )
+    username: Mapped[str] = mapped_column(
+        String(50), unique=True, nullable=False, index=True
+    )
+    email: Mapped[str] = mapped_column(
+        String(255), unique=True, nullable=False, index=True
+    )
+    hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
+    first_name: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    last_name: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
     # Relationships
-    meal = relationship("Meal", back_populates="user")
+    meal: Mapped[list[Meal]] = relationship("Meal", back_populates="user")

--- a/apps/backend/src/schemas/auth.py
+++ b/apps/backend/src/schemas/auth.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, Field
+
+
+class Token(BaseModel):
+    access_token: str = Field(..., description="Access token for authentication")
+    token_type: str = Field(..., description="Type of the token, e.g., 'bearer'")
+
+
+class TokenData(BaseModel):
+    sub: str | None = Field(
+        default=None,
+        description="Subject (user identifier) of the token",
+    )
+    scopes: list[str] = Field(
+        default_factory=list,
+        description="Scopes/permissions associated with the token",
+    )
+
+
+class LoginResponse(Token):
+    """Response model for login, extending Token with user info."""
+
+    user_id: str = Field(..., description="Unique identifier for the user")
+    email: str = Field(..., description="Email of the authenticated user")

--- a/apps/backend/src/schemas/user.py
+++ b/apps/backend/src/schemas/user.py
@@ -1,11 +1,12 @@
 from uuid import UUID
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 
 class UserBase(BaseModel):
     email: EmailStr = Field(..., description="User's email address")
     username: str = Field(..., min_length=3, max_length=50, description="Username")
+    model_config = ConfigDict(from_attributes=True)
 
 
 class UserCreate(UserBase):
@@ -36,6 +37,8 @@ class UserUpdate(BaseModel):
 
 class UserPublic(UserBase):
     id: UUID = Field(..., description="Unique identifier for the user")
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class UserInDB(UserBase):

--- a/apps/backend/src/schemas/user.py
+++ b/apps/backend/src/schemas/user.py
@@ -1,0 +1,49 @@
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class UserBase(BaseModel):
+    email: EmailStr = Field(..., description="User's email address")
+    username: str = Field(..., min_length=3, max_length=50, description="Username")
+
+
+class UserCreate(UserBase):
+    password: str = Field(..., min_length=6, description="User's password")
+    first_name: str | None = Field(
+        default=None, max_length=50, description="User's first name"
+    )
+    last_name: str | None = Field(
+        default=None, max_length=50, description="User's last name"
+    )
+
+
+class UserUpdate(BaseModel):
+    email: EmailStr | None = Field(default=None, description="User's email address")
+    username: str | None = Field(
+        default=None, min_length=3, max_length=50, description="Username"
+    )
+    password: str | None = Field(
+        default=None, min_length=6, description="User's password"
+    )
+    first_name: str | None = Field(
+        default=None, max_length=50, description="User's first name"
+    )
+    last_name: str | None = Field(
+        default=None, max_length=50, description="User's last name"
+    )
+
+
+class UserPublic(UserBase):
+    id: UUID = Field(..., description="Unique identifier for the user")
+
+
+class UserInDB(UserBase):
+    id: UUID = Field(..., description="Unique identifier for the user")
+    hashed_password: str = Field(..., description="Hashed password for the user")
+    first_name: str | None = Field(
+        default=None, max_length=50, description="User's first name"
+    )
+    last_name: str | None = Field(
+        default=None, max_length=50, description="User's last name"
+    )

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -1,16 +1,60 @@
-"""
-Shared test fixtures for pytest.
+"""Shared test fixtures for pytest.
+
+We set minimal env defaults (e.g. SECRET_KEY) early so importing modules
+that instantiate settings (core.security) succeeds without needing an
+external .env file during tests.
 """
 
+import os
+import uuid
 from collections.abc import AsyncGenerator, Generator
 
 import pytest
 import pytest_asyncio
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+
+from core.security import get_password_hash
+from dependencies.auth import get_current_user
 from dependencies.db import get_db
 from main import app
+from models.users import User
+
+
+async def _ensure_demo_user(db: AsyncSession) -> User:
+    """Create (or fetch) a demo user for non-auth focused tests.
+
+    These tests previously assumed public endpoints; now that most routes are
+    protected we override auth to always return this user. Auth-specific tests
+    remove this override to exercise the real dependency chain.
+    """
+    result = await db.execute(
+        # Simple query; defer import complexity by inline text
+        User.__table__.select().limit(1)  # type: ignore[arg-type]
+    )
+    row = result.first()
+    if row:
+        # Row 0 is the user instance when selecting table directly may differ;
+        # safest is to re-query via ORM if needed, but for simplicity return id lookup.
+        user = await db.get(User, row[0])  # type: ignore[index]
+        if user:
+            return user
+    demo = User(
+        id=uuid.uuid4(),
+        username="demo",
+        email="demo@example.test",
+        hashed_password=get_password_hash("password"),
+        first_name="Demo",
+        last_name="User",
+    )
+    db.add(demo)
+    await db.commit()
+    await db.refresh(demo)
+    return demo
 
 
 @pytest.fixture
@@ -22,57 +66,64 @@ def client() -> Generator[TestClient, None, None]:
         yield client
 
 
+class _FakeResult:
+    """Lightweight stand-in for a SQLAlchemy result."""
+
+    def scalars(self):
+        return self
+
+    def first(self):  # pragma: no cover - trivial
+        return None
+
+
+class _FakeSession:
+    """Minimal fake async session used in lightweight tests.
+
+    Only the small surface area required by current tests is implemented.
+    """
+
+    def add(self, _obj):  # pragma: no cover - no-op
+        return None
+
+    async def flush(self):  # pragma: no cover - no-op
+        return None
+
+    async def execute(self, _stmt):  # Always empty result
+        return _FakeResult()
+
+    async def commit(self):  # pragma: no cover - no-op
+        return None
+
+    async def rollback(self):  # pragma: no cover - no-op
+        return None
+
+    async def close(self):  # pragma: no cover - no-op
+        return None
+
+
+async def _override_get_db_factory() -> AsyncGenerator[_FakeSession, None]:
+    """Yield a fake session for dependency override."""
+    fake = _FakeSession()
+    try:
+        yield fake
+    finally:  # pragma: no cover - cleanup path
+        await fake.close()
+
+
+async def _override_get_current_user_factory():  # pragma: no cover - simple helper
+    class _DummyUser:
+        id = uuid.uuid4()
+
+    return _DummyUser()
+
+
 @pytest_asyncio.fixture
 async def async_client() -> AsyncGenerator[AsyncClient, None]:
-    """
-    Create an async test client for the FastAPI application.
-    """
-
-    # Minimal fake async SQLAlchemy session for tests
-    class _FakeResult:
-        def scalars(self):
-            return self
-
-        def first(self):
-            return None
-
-    class _FakeSession:
-        def add(self, _obj):
-            # No-op add; objects already have IDs assigned in code
-            return None
-
-        async def flush(self):
-            return None
-
-        async def execute(self, _stmt):
-            # Return empty result so ingredients get created
-            return _FakeResult()
-
-        async def commit(self):
-            return None
-
-        async def rollback(self):
-            return None
-
-        async def close(self):
-            return None
-
-    async def _override_get_db():
-        fake = _FakeSession()
-        try:
-            yield fake
-        finally:
-            await fake.close()
-
-    # Apply dependency override
-    app.dependency_overrides[get_db] = _override_get_db
-    # Create a transport that uses the FastAPI app
+    """Async client with DB & auth overrides (auto-auth)."""
+    app.dependency_overrides[get_db] = _override_get_db_factory
+    app.dependency_overrides[get_current_user] = _override_get_current_user_factory
     transport = ASGITransport(app=app)
-
-    # Create an AsyncClient with the transport and a proper base URL with scheme
     async with AsyncClient(transport=transport, base_url="http://testserver") as client:
-        try:
-            yield client
-        finally:
-            # Clean override to avoid bleeding between tests
-            app.dependency_overrides.pop(get_db, None)
+        yield client
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(get_current_user, None)

--- a/apps/backend/tests/test_auth.py
+++ b/apps/backend/tests/test_auth.py
@@ -1,0 +1,196 @@
+"""Authorization & authentication tests for PantryPilot.
+
+Covers:
+- Successful login returns token
+- Login failure wrong password
+- Protected endpoint 401 without token (real dependency)
+- Protected endpoint 200 with valid token
+- Expired token rejected
+- Invalid token rejected
+- Token missing `sub` claim rejected
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from fastapi import status
+from httpx import ASGITransport, AsyncClient
+from jose import jwt
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from core.config import get_settings
+from core.security import create_access_token, get_password_hash
+from dependencies.auth import get_current_user
+from dependencies.db import get_db
+from main import app
+from models.base import Base
+from models.meal_history import Meal
+from models.users import User
+
+
+settings = get_settings()
+
+
+@pytest_asyncio.fixture
+async def auth_client() -> AsyncGenerator[tuple[AsyncClient, AsyncSession], None]:
+    """Client + real in-memory SQLite DB with full schema for auth tests.
+
+    Removes any auth override so routes are actually protected.
+    """
+    # Ensure no auth override from generic fixtures
+    app.dependency_overrides.pop(get_current_user, None)
+
+    engine: AsyncEngine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", future=True
+    )
+    async with engine.begin() as conn:
+        # Create minimal subset of tables to satisfy auth & mealplans tests.
+        # Avoid Recipe model (Postgres ARRAY) which SQLite can't compile.
+        await conn.exec_driver_sql(
+            "CREATE TABLE IF NOT EXISTS recipe_names (id BLOB PRIMARY KEY)"
+        )
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn, tables=[User.__table__, Meal.__table__]
+            )
+        )
+
+    SessionLocal = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+
+    async def _override_get_db():
+        async with SessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        async with SessionLocal() as session:
+            yield c, session
+    app.dependency_overrides.pop(get_db, None)
+    await engine.dispose()
+
+
+async def _create_user(db: AsyncSession, username: str = "alice") -> User:
+    user = User(
+        username=username,
+        email=f"{username}@example.test",
+        hashed_password=get_password_hash("secret"),
+        first_name="A",
+        last_name="User",
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+@pytest.mark.asyncio
+async def test_login_success(auth_client: tuple[AsyncClient, AsyncSession]):
+    client, db = auth_client
+    user = await _create_user(db)
+    resp = await client.post(
+        "/api/v1/auth/login",
+        data={"username": user.username, "password": "secret"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    payload = resp.json()
+    assert payload["access_token"]
+    assert payload["token_type"] == "bearer"
+
+
+@pytest.mark.asyncio
+async def test_login_wrong_password(auth_client: tuple[AsyncClient, AsyncSession]):
+    client, db = auth_client
+    user = await _create_user(db, username="bob")
+
+    resp = await client.post(
+        "/api/v1/auth/login",
+        data={"username": user.username, "password": "not-secret"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+    assert resp.json()["detail"] == "Incorrect username or password"
+
+
+@pytest.mark.asyncio
+async def test_protected_endpoint_requires_token(
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    client, _ = auth_client
+    resp = await client.get("/api/v1/mealplans/weekly?start=2025-01-14")
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+    assert resp.headers["www-authenticate"].lower().startswith("bearer")
+
+
+@pytest.mark.asyncio
+async def test_protected_endpoint_with_token(
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    client, db = auth_client
+    user = await _create_user(db, username="carol")
+    token = create_access_token(
+        {"sub": str(user.id)}, expires_delta=timedelta(minutes=5)
+    )
+    resp = await client.get(
+        "/api/v1/mealplans/weekly?start=2025-01-14",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code != status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_expired_token_rejected(auth_client: tuple[AsyncClient, AsyncSession]):
+    client, db = auth_client
+    user = await _create_user(db, username="dave")
+    expired = create_access_token(
+        {"sub": str(user.id)}, expires_delta=timedelta(minutes=-1)
+    )
+    resp = await client.get(
+        "/api/v1/mealplans/weekly?start=2025-01-12",
+        headers={"Authorization": f"Bearer {expired}"},
+    )
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+    assert resp.json()["detail"] in {
+        "Could not validate credentials",
+        "Token missing subject",
+    }
+
+
+@pytest.mark.asyncio
+async def test_invalid_token(auth_client: tuple[AsyncClient, AsyncSession]):
+    client, _ = auth_client
+    # Completely invalid token string
+    resp = await client.get(
+        "/api/v1/mealplans/weekly?start=2025-01-12",
+        headers={"Authorization": "Bearer not.a.jwt"},
+    )
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_token_missing_sub_claim(auth_client: tuple[AsyncClient, AsyncSession]):
+    client, db = auth_client
+    # Create user so DB not empty; but build token without sub
+    await _create_user(db, username="eve")
+    no_sub = jwt.encode(
+        {"exp": datetime.now(UTC) + timedelta(minutes=5)},
+        settings.SECRET_KEY,
+        algorithm=settings.ALGORITHM,
+    )
+    resp = await client.get(
+        "/api/v1/mealplans/weekly?start=2025-01-12",
+        headers={"Authorization": f"Bearer {no_sub}"},
+    )
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED

--- a/apps/backend/tests/test_auth_edge_cases.py
+++ b/apps/backend/tests/test_auth_edge_cases.py
@@ -1,0 +1,78 @@
+"""Auth edge case tests (unknown user, missing DB user for token)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException, status
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from core.security import create_access_token
+from dependencies.auth import get_current_user
+from dependencies.db import get_db
+from main import app
+from models.base import Base
+from models.users import User
+
+
+@pytest_asyncio.fixture
+async def user_db() -> AsyncGenerator[AsyncSession, None]:
+    engine: AsyncEngine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", future=True, poolclass=StaticPool
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync: Base.metadata.create_all(sync, tables=[User.__table__])
+        )
+    SessionLocal = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    async with SessionLocal() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def auth_http(user_db: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
+    async def _override_get_db():
+        yield user_db
+
+    app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides[get_db] = _override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        yield c
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.asyncio
+async def test_login_unknown_username(auth_http: AsyncClient):
+    resp = await auth_http.post(
+        "/api/v1/auth/login",
+        data={"username": "doesnotexist", "password": "whatever"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+    assert resp.json()["detail"] == "Incorrect username or password"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_user_not_found(user_db: AsyncSession):
+    ghost_id = uuid4()
+    token = create_access_token(
+        {"sub": str(ghost_id)}, expires_delta=timedelta(minutes=5)
+    )
+    with pytest.raises(HTTPException) as exc:
+        await get_current_user(user_db, token)  # type: ignore[arg-type]
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED

--- a/apps/backend/tests/test_user_crud.py
+++ b/apps/backend/tests/test_user_crud.py
@@ -1,0 +1,93 @@
+"""User CRUD helper & schema tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from core.security import get_password_hash
+from crud.user import (
+    create_user,
+    get_user_by_email,
+    get_user_by_id,
+    get_user_by_username,
+)
+from dependencies.db import get_db
+from main import app
+from models.base import Base
+from models.users import User
+from schemas.user import UserInDB, UserPublic
+
+
+@pytest_asyncio.fixture
+async def db_user_only() -> AsyncGenerator[AsyncSession, None]:
+    engine: AsyncEngine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", future=True, poolclass=StaticPool
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync: Base.metadata.create_all(sync, tables=[User.__table__])
+        )
+    SessionLocal = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    async with SessionLocal() as session:
+        yield session
+    await engine.dispose()
+
+
+def test_user_schema_serialization():
+    uid = uuid4()
+    public = UserPublic(id=uid, email="u@example.com", username="user")
+    assert public.id == uid
+    in_db = UserInDB(
+        id=uid,
+        email="u@example.com",
+        username="user",
+        hashed_password="hash",
+        first_name=None,
+        last_name=None,
+    )
+    payload = in_db.model_dump()
+    assert payload["hashed_password"] == "hash"
+
+
+@pytest_asyncio.fixture
+async def crud_db_http(db_user_only: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
+    async def _override_get_db():
+        yield db_user_only
+
+    app.dependency_overrides[get_db] = _override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        yield c
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.asyncio
+async def test_user_crud_helpers(db_user_only: AsyncSession):  # noqa: D103
+    assert await get_user_by_username(db_user_only, "alpha") is None
+    user = await create_user(
+        db_user_only,
+        email="alpha@example.com",
+        username="alpha",
+        hashed_password=get_password_hash("pw-secure"),
+        first_name="Al",
+        last_name="Pha",
+    )
+    assert await get_user_by_username(db_user_only, "alpha") is not None
+    assert await get_user_by_email(db_user_only, "alpha@example.com") is not None
+    assert await get_user_by_id(db_user_only, user.id) is not None
+    assert await get_user_by_username(db_user_only, "missing") is None
+    assert await get_user_by_email(db_user_only, "missing@example.com") is None

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 1
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "aiosqlite"
@@ -52,6 +56,77 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings", version = "21.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "argon2-cffi-bindings", version = "25.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657 },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "21.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "cffi", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/e9/184b8ccce6683b0aa2fbb7ba5683ea4b9c5763f1356347f1312c32e3c66e/argon2-cffi-bindings-21.2.0.tar.gz", hash = "sha256:bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3", size = 1779911 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/13/838ce2620025e9666aa8f686431f67a29052241692a3dd1ae9d3692a89d3/argon2_cffi_bindings-21.2.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ccb949252cb2ab3a08c02024acb77cfb179492d5701c7cbdbfd776124d4d2367", size = 29658 },
+    { url = "https://files.pythonhosted.org/packages/b3/02/f7f7bb6b6af6031edb11037639c697b912e1dea2db94d436e681aea2f495/argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9524464572e12979364b7d600abf96181d3541da11e23ddf565a32e70bd4dc0d", size = 80583 },
+    { url = "https://files.pythonhosted.org/packages/ec/f7/378254e6dd7ae6f31fe40c8649eea7d4832a42243acaf0f1fff9083b2bed/argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b746dba803a79238e925d9046a63aa26bf86ab2a2fe74ce6b009a1c3f5c8f2ae", size = 86168 },
+    { url = "https://files.pythonhosted.org/packages/74/f6/4a34a37a98311ed73bb80efe422fed95f2ac25a4cacc5ae1d7ae6a144505/argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58ed19212051f49a523abb1dbe954337dc82d947fb6e5a0da60f7c8471a8476c", size = 82709 },
+    { url = "https://files.pythonhosted.org/packages/74/2b/73d767bfdaab25484f7e7901379d5f8793cccbb86c6e0cbc4c1b96f63896/argon2_cffi_bindings-21.2.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:bd46088725ef7f58b5a1ef7ca06647ebaf0eb4baff7d1d0d177c6cc8744abd86", size = 83613 },
+    { url = "https://files.pythonhosted.org/packages/4f/fd/37f86deef67ff57c76f137a67181949c2d408077e2e3dd70c6c42912c9bf/argon2_cffi_bindings-21.2.0-cp36-abi3-musllinux_1_1_i686.whl", hash = "sha256:8cd69c07dd875537a824deec19f978e0f2078fdda07fd5c42ac29668dda5f40f", size = 84583 },
+    { url = "https://files.pythonhosted.org/packages/6f/52/5a60085a3dae8fded8327a4f564223029f5f54b0cb0455a31131b5363a01/argon2_cffi_bindings-21.2.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f1152ac548bd5b8bcecfb0b0371f082037e47128653df2e8ba6e914d384f3c3e", size = 88475 },
+    { url = "https://files.pythonhosted.org/packages/8b/95/143cd64feb24a15fa4b189a3e1e7efbaeeb00f39a51e99b26fc62fbacabd/argon2_cffi_bindings-21.2.0-cp36-abi3-win32.whl", hash = "sha256:603ca0aba86b1349b147cab91ae970c63118a0f30444d4bc80355937c950c082", size = 27698 },
+    { url = "https://files.pythonhosted.org/packages/37/2c/e34e47c7dee97ba6f01a6203e0383e15b60fb85d78ac9a15cd066f6fe28b/argon2_cffi_bindings-21.2.0-cp36-abi3-win_amd64.whl", hash = "sha256:b2ef1c30440dbbcba7a5dc3e319408b59676e2e039e2ae11a8775ecf482b192f", size = 30817 },
+    { url = "https://files.pythonhosted.org/packages/5a/e4/bf8034d25edaa495da3c8a3405627d2e35758e44ff6eaa7948092646fdcc/argon2_cffi_bindings-21.2.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e415e3f62c8d124ee16018e491a009937f8cf7ebf5eb430ffc5de21b900dad93", size = 53104 },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.14'",
+]
+dependencies = [
+    { name = "cffi", marker = "python_full_version < '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393 },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328 },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269 },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558 },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364 },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637 },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934 },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158 },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597 },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231 },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121 },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177 },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090 },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246 },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126 },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343 },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777 },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180 },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715 },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149 },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -81,11 +156,15 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "argon2-cffi" },
     { name = "asyncpg" },
     { name = "fastapi", extra = ["standard"] },
     { name = "greenlet" },
     { name = "gunicorn" },
+    { name = "pydantic-settings" },
+    { name = "python-jose", extra = ["cryptography"] },
     { name = "sqlalchemy" },
+    { name = "types-python-jose" },
     { name = "uvicorn" },
 ]
 
@@ -104,11 +183,15 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.16.4" },
+    { name = "argon2-cffi", specifier = ">=25.1.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.116.1" },
     { name = "greenlet", specifier = ">=3.0.0" },
     { name = "gunicorn", specifier = ">=23.0.0" },
+    { name = "pydantic-settings", specifier = ">=2.10.1" },
+    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.5.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
+    { name = "types-python-jose", specifier = ">=3.5.0.20250531" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
 
@@ -131,6 +214,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/76/52c535bcebe74590f296d6c77c86dabf761c41980e1347a2422e4aa2ae41/certifi-2025.7.14.tar.gz", hash = "sha256:8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995", size = 163981 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/52/34c6cf5bb9285074dc3531c437b3919e825d976fde097a7a73f79e726d03/certifi-2025.7.14-py3-none-any.whl", hash = "sha256:6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2", size = 162722 },
+]
+
+[[package]]
+name = "cffi"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/84/e94227139ee5fb4d600a7a4927f322e1d4aea6fdc50bd3fca8493caba23f/cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4", size = 183178 },
+    { url = "https://files.pythonhosted.org/packages/da/ee/fb72c2b48656111c4ef27f0f91da355e130a923473bf5ee75c5643d00cca/cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c", size = 178840 },
+    { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803 },
+    { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850 },
+    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729 },
+    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256 },
+    { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424 },
+    { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568 },
+    { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736 },
+    { url = "https://files.pythonhosted.org/packages/86/c5/28b2d6f799ec0bdecf44dced2ec5ed43e0eb63097b0f58c293583b406582/cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65", size = 172448 },
+    { url = "https://files.pythonhosted.org/packages/50/b9/db34c4755a7bd1cb2d1603ac3863f22bcecbd1ba29e5ee841a4bc510b294/cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903", size = 181976 },
+    { url = "https://files.pythonhosted.org/packages/8d/f8/dd6c246b148639254dad4d6803eb6a54e8c85c6e11ec9df2cffa87571dbe/cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e", size = 182989 },
+    { url = "https://files.pythonhosted.org/packages/8b/f1/672d303ddf17c24fc83afd712316fda78dc6fce1cd53011b839483e1ecc8/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2", size = 178802 },
+    { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792 },
+    { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893 },
+    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810 },
+    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200 },
+    { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447 },
+    { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358 },
+    { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469 },
+    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475 },
+    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009 },
 ]
 
 [[package]]
@@ -228,6 +344,41 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "45.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/35/c495bffc2056f2dadb32434f1feedd79abde2a7f8363e1974afa9c33c7e2/cryptography-45.0.7.tar.gz", hash = "sha256:4b1654dfc64ea479c242508eb8c724044f1e964a47d1d1cacc5132292d851971", size = 744980 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/91/925c0ac74362172ae4516000fe877912e33b5983df735ff290c653de4913/cryptography-45.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3be4f21c6245930688bd9e162829480de027f8bf962ede33d4f8ba7d67a00cee", size = 7041105 },
+    { url = "https://files.pythonhosted.org/packages/fc/63/43641c5acce3a6105cf8bd5baeceeb1846bb63067d26dae3e5db59f1513a/cryptography-45.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:67285f8a611b0ebc0857ced2081e30302909f571a46bfa7a3cc0ad303fe015c6", size = 4205799 },
+    { url = "https://files.pythonhosted.org/packages/bc/29/c238dd9107f10bfde09a4d1c52fd38828b1aa353ced11f358b5dd2507d24/cryptography-45.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:577470e39e60a6cd7780793202e63536026d9b8641de011ed9d8174da9ca5339", size = 4430504 },
+    { url = "https://files.pythonhosted.org/packages/62/62/24203e7cbcc9bd7c94739428cd30680b18ae6b18377ae66075c8e4771b1b/cryptography-45.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4bd3e5c4b9682bc112d634f2c6ccc6736ed3635fc3319ac2bb11d768cc5a00d8", size = 4209542 },
+    { url = "https://files.pythonhosted.org/packages/cd/e3/e7de4771a08620eef2389b86cd87a2c50326827dea5528feb70595439ce4/cryptography-45.0.7-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:465ccac9d70115cd4de7186e60cfe989de73f7bb23e8a7aa45af18f7412e75bf", size = 3889244 },
+    { url = "https://files.pythonhosted.org/packages/96/b8/bca71059e79a0bb2f8e4ec61d9c205fbe97876318566cde3b5092529faa9/cryptography-45.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:16ede8a4f7929b4b7ff3642eba2bf79aa1d71f24ab6ee443935c0d269b6bc513", size = 4461975 },
+    { url = "https://files.pythonhosted.org/packages/58/67/3f5b26937fe1218c40e95ef4ff8d23c8dc05aa950d54200cc7ea5fb58d28/cryptography-45.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8978132287a9d3ad6b54fcd1e08548033cc09dc6aacacb6c004c73c3eb5d3ac3", size = 4209082 },
+    { url = "https://files.pythonhosted.org/packages/0e/e4/b3e68a4ac363406a56cf7b741eeb80d05284d8c60ee1a55cdc7587e2a553/cryptography-45.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b6a0e535baec27b528cb07a119f321ac024592388c5681a5ced167ae98e9fff3", size = 4460397 },
+    { url = "https://files.pythonhosted.org/packages/22/49/2c93f3cd4e3efc8cb22b02678c1fad691cff9dd71bb889e030d100acbfe0/cryptography-45.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a24ee598d10befaec178efdff6054bc4d7e883f615bfbcd08126a0f4931c83a6", size = 4337244 },
+    { url = "https://files.pythonhosted.org/packages/04/19/030f400de0bccccc09aa262706d90f2ec23d56bc4eb4f4e8268d0ddf3fb8/cryptography-45.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fa26fa54c0a9384c27fcdc905a2fb7d60ac6e47d14bc2692145f2b3b1e2cfdbd", size = 4568862 },
+    { url = "https://files.pythonhosted.org/packages/29/56/3034a3a353efa65116fa20eb3c990a8c9f0d3db4085429040a7eef9ada5f/cryptography-45.0.7-cp311-abi3-win32.whl", hash = "sha256:bef32a5e327bd8e5af915d3416ffefdbe65ed975b646b3805be81b23580b57b8", size = 2936578 },
+    { url = "https://files.pythonhosted.org/packages/b3/61/0ab90f421c6194705a99d0fa9f6ee2045d916e4455fdbb095a9c2c9a520f/cryptography-45.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:3808e6b2e5f0b46d981c24d79648e5c25c35e59902ea4391a0dcb3e667bf7443", size = 3405400 },
+    { url = "https://files.pythonhosted.org/packages/63/e8/c436233ddf19c5f15b25ace33979a9dd2e7aa1a59209a0ee8554179f1cc0/cryptography-45.0.7-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bfb4c801f65dd61cedfc61a83732327fafbac55a47282e6f26f073ca7a41c3b2", size = 7021824 },
+    { url = "https://files.pythonhosted.org/packages/bc/4c/8f57f2500d0ccd2675c5d0cc462095adf3faa8c52294ba085c036befb901/cryptography-45.0.7-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:81823935e2f8d476707e85a78a405953a03ef7b7b4f55f93f7c2d9680e5e0691", size = 4202233 },
+    { url = "https://files.pythonhosted.org/packages/eb/ac/59b7790b4ccaed739fc44775ce4645c9b8ce54cbec53edf16c74fd80cb2b/cryptography-45.0.7-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3994c809c17fc570c2af12c9b840d7cea85a9fd3e5c0e0491f4fa3c029216d59", size = 4423075 },
+    { url = "https://files.pythonhosted.org/packages/b8/56/d4f07ea21434bf891faa088a6ac15d6d98093a66e75e30ad08e88aa2b9ba/cryptography-45.0.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dad43797959a74103cb59c5dac71409f9c27d34c8a05921341fb64ea8ccb1dd4", size = 4204517 },
+    { url = "https://files.pythonhosted.org/packages/e8/ac/924a723299848b4c741c1059752c7cfe09473b6fd77d2920398fc26bfb53/cryptography-45.0.7-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ce7a453385e4c4693985b4a4a3533e041558851eae061a58a5405363b098fcd3", size = 3882893 },
+    { url = "https://files.pythonhosted.org/packages/83/dc/4dab2ff0a871cc2d81d3ae6d780991c0192b259c35e4d83fe1de18b20c70/cryptography-45.0.7-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b04f85ac3a90c227b6e5890acb0edbaf3140938dbecf07bff618bf3638578cf1", size = 4450132 },
+    { url = "https://files.pythonhosted.org/packages/12/dd/b2882b65db8fc944585d7fb00d67cf84a9cef4e77d9ba8f69082e911d0de/cryptography-45.0.7-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:48c41a44ef8b8c2e80ca4527ee81daa4c527df3ecbc9423c41a420a9559d0e27", size = 4204086 },
+    { url = "https://files.pythonhosted.org/packages/5d/fa/1d5745d878048699b8eb87c984d4ccc5da4f5008dfd3ad7a94040caca23a/cryptography-45.0.7-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f3df7b3d0f91b88b2106031fd995802a2e9ae13e02c36c1fc075b43f420f3a17", size = 4449383 },
+    { url = "https://files.pythonhosted.org/packages/36/8b/fc61f87931bc030598e1876c45b936867bb72777eac693e905ab89832670/cryptography-45.0.7-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd342f085542f6eb894ca00ef70236ea46070c8a13824c6bde0dfdcd36065b9b", size = 4332186 },
+    { url = "https://files.pythonhosted.org/packages/0b/11/09700ddad7443ccb11d674efdbe9a832b4455dc1f16566d9bd3834922ce5/cryptography-45.0.7-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1993a1bb7e4eccfb922b6cd414f072e08ff5816702a0bdb8941c247a6b1b287c", size = 4561639 },
+    { url = "https://files.pythonhosted.org/packages/71/ed/8f4c1337e9d3b94d8e50ae0b08ad0304a5709d483bfcadfcc77a23dbcb52/cryptography-45.0.7-cp37-abi3-win32.whl", hash = "sha256:18fcf70f243fe07252dcb1b268a687f2358025ce32f9f88028ca5c364b123ef5", size = 2926552 },
+    { url = "https://files.pythonhosted.org/packages/bc/ff/026513ecad58dacd45d1d24ebe52b852165a26e287177de1d545325c0c25/cryptography-45.0.7-cp37-abi3-win_amd64.whl", hash = "sha256:7285a89df4900ed3bfaad5679b1e668cb4b38a8de1ccbfc84b05f34512da0a90", size = 3392742 },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -243,6 +394,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632 },
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607 },
 ]
 
 [[package]]
@@ -640,6 +803,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135 },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552 },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -702,6 +883,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", size = 45235 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -759,6 +954,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556 },
+]
+
+[[package]]
+name = "python-jose"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ecdsa" },
+    { name = "pyasn1" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624 },
+]
+
+[package.optional-dependencies]
+cryptography = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -870,6 +1084,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696 },
+]
+
+[[package]]
 name = "ruff"
 version = "0.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -914,6 +1140,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
 ]
 
 [[package]]
@@ -980,6 +1215,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317 },
+]
+
+[[package]]
+name = "types-pyasn1"
+version = "0.6.0.20250516"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/9b/5c6e6690da87e9fec317925d4a9500a8d61c2e2c1ec39de46736f76a29e8/types_pyasn1-0.6.0.20250516.tar.gz", hash = "sha256:1a9b35a4f033cd70c384a5043a3407b2cc07afc95900732b66e0d38426c7541d", size = 17153 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/56/0d10029d4d943226f044cec3f3d1f9ad54acb4884ee0b78e5d7b66c07d9d/types_pyasn1-0.6.0.20250516-py3-none-any.whl", hash = "sha256:b9925e4e22e09eed758b93b6f2a7881b89d842c2373dd11c09b173567d170142", size = 24093 },
+]
+
+[[package]]
+name = "types-python-jose"
+version = "3.5.0.20250531"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/c8/09095e22b8e5eb3992f47722a3e1b31098b55c5e8325f4b21c5f1bdcb06b/types_python_jose-3.5.0.20250531.tar.gz", hash = "sha256:dbac2bc99fbb8124068696617f8709acfe4a43d79c6df3e59800006d46d621fe", size = 11891 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/33/9d8c351a44e68896a53003e00fb01e1158b9e5b68cf3b75c1e4b51eb5263/types_python_jose-3.5.0.20250531-py3-none-any.whl", hash = "sha256:1609ee4d40a8a2ef5f62fcda99ec977b2ae773dfee9355cfb7e5002afa063c55", size = 14725 },
 ]
 
 [[package]]

--- a/apps/frontend/src/components/HydrateFallback.tsx
+++ b/apps/frontend/src/components/HydrateFallback.tsx
@@ -1,0 +1,3 @@
+export default function HydrateFallback() {
+  return <div className="p-4 text-sm text-gray-500">Loading application…</div>;
+}

--- a/apps/frontend/src/routerConfig.tsx
+++ b/apps/frontend/src/routerConfig.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter } from 'react-router-dom';
+import HydrateFallback from './components/HydrateFallback';
 import Root from './components/Root';
 import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
@@ -60,6 +61,7 @@ export const router = createBrowserRouter([
   {
     path: '/',
     element: <Root />,
+    HydrateFallback,
     children: [
       {
         index: true,


### PR DESCRIPTION
# PR: Minimal JWT Auth + Argon2 password hashing + protected routes

## Summary
This PR implements a minimal JWT-based auth stack on the backend and wires protected routes so API endpoints require authentication by default. It also adds tests that exercise the auth flow and a small frontend hydration component.

## Key changes
- Settings and CORS validation: `apps/backend/src/core/config.py` (explicit origin parsing, no wildcard when credentials allowed).
- Security utilities: `apps/backend/src/core/security.py` (JWT creation/decoding, Argon2 password hashing).
- Auth dependency: `apps/backend/src/dependencies/auth.py` (`OAuth2PasswordBearer` + `get_current_user` that returns 401 + `WWW-Authenticate: Bearer` on failure).
- Login endpoint: `apps/backend/src/api/v1/auth.py` (POST `/api/v1/auth/login`, returns `{access_token, token_type}`).
- User model & CRUD: `apps/backend/src/models/users.py`, `apps/backend/src/crud/user.py`, and dev user script `apps/backend/scripts/create_dev_user.py`.
- Router wiring: `apps/backend/src/api/v1/api.py` includes the auth router and mounts other routers with `Depends(get_current_user)` making them protected.
- Schemas: `apps/backend/src/schemas/auth.py`, `apps/backend/src/schemas/user.py`.
- Tests: full auth tests and updated fixtures in `apps/backend/tests/`.
- Frontend: `apps/frontend/src/components/HydrateFallback.tsx` and a small route config change; frontend auth store/client remains to be implemented.

## Files changed (high level)
- apps/backend/src/core/config.py
- apps/backend/src/core/security.py
- apps/backend/src/dependencies/auth.py
- apps/backend/src/api/v1/auth.py
- apps/backend/src/api/v1/api.py
- apps/backend/src/schemas/auth.py
- apps/backend/src/schemas/user.py
- apps/backend/src/models/users.py
- apps/backend/src/crud/user.py
- apps/backend/scripts/create_dev_user.py
- apps/backend/tests/* (auth tests, conftest updates)
- apps/frontend/src/components/HydrateFallback.tsx
- apps/frontend/src/routerConfig.tsx

## Acceptance checklist mapping
- POST /api/v1/auth/login: implemented and returns `{access_token, token_type}`; 401 on bad creds with `WWW-Authenticate` header.
- `get_current_user` dependency: implemented; decodes token, validates `sub`, loads user from DB, returns 401 + `WWW-Authenticate` on failure.
- JWT utilities: implemented with `exp` claim and algorithm restriction.
- Password hashing: Argon2 via `argon2-cffi` used for `get_password_hash`/`verify_password`.
- CORS: uses explicit origins from settings and prevents wildcard when credentials allowed.
- Schemas: token and user schemas added.
- User CRUD and model: implemented.
- Router protection: applied via router-level dependency.
- Tests: added/updated to exercise login flow, expiry, invalid tokens, and edge cases.

## What remains (frontend)
- Implement Zustand auth store with persisted token and hydration guard.
- Implement `apps/frontend/src/api/client.ts` to include Authorization header when token available.
- Implement `apps/frontend/src/api/auth.ts` and a `LoginPage` wiring to call `/api/v1/auth/login`.

## Testing instructions
1. Ensure `.env.dev` contains a `SECRET_KEY` and CORS_ORIGINS e.g. `http://localhost:5173`.
2. From repo root run:

```bash
cd apps/backend
uv run pytest -q
```

3. Manual API checks:

```bash
# login (form data)
curl -X POST "http://localhost:8000/api/v1/auth/login" \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "username=dev&password=devdevdev"

# protected endpoint should return 401 without Authorization header
curl "http://localhost:8000/api/v1/mealplans/weekly?start=2025-01-14"

# use token in header
curl "http://localhost:8000/api/v1/mealplans/weekly?start=2025-01-14" \
  -H "Authorization: Bearer <token>"
```

## Notes & recommendations
- `SECRET_KEY` must be set in `.env.dev` for development (example generation: `python -c "import secrets; print(secrets.token_urlsafe(32))"`).
- Frontend changes are minimal in this branch; recommend implementing the frontend pieces in a follow-up PR and then testing end-to-end.
- Argon2 used for new passwords; if you need to migrate bcrypt/passlib hashes, plan a migration strategy.

If you'd like, I can open a follow-up branch/PR that implements the frontend auth store and client and wires the Login page to the new backend endpoints.

