### PR TITLE
Feat/registration

### DIFF
--- a/.kilocode/mcp.json
+++ b/.kilocode/mcp.json
@@ -1,0 +1,21 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp"
+      ],
+      "env": {
+        "DEFAULT_MINIMUM_TOKENS": ""
+      }
+    },
+    "sequentialthinking": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ]
+    }
+  }
+}

--- a/.kilocode/rules/memory-bank/architecture.md
+++ b/.kilocode/rules/memory-bank/architecture.md
@@ -1,0 +1,69 @@
+# Architecture
+
+## Runtime topology (Docker Compose)
+PantryPilot runs via Docker Compose with environment-specific overlays. The environment is selected by the ENV make variable: dev (default) or prod. Compose files include a base file plus an environment-specific file, and the corresponding .env.* file is loaded for variables.
+
+- Base compose file: docker-compose.yml
+- Dev overlay: docker-compose.dev.yml
+- Prod overlay: docker-compose.prod.yml
+- Env files: .env.dev or .env.prod
+
+Services (names referenced by Makefile targets):
+- backend: FastAPI app container; runs migrations and app process
+- db: PostgreSQL
+- frontend: Vite/React dev or built app (depending on environment)
+
+## Startup flow (make up)
+make up performs:
+1. docker compose up -d using the selected env file and compose files
+2. Waits for db readiness using pg_isready inside the db service
+3. Runs Alembic migrations inside the backend container:
+   uv run alembic -c /app/src/alembic.ini upgrade head
+
+This ensures database schema is current on every start.
+
+Aliases:
+- make dev → make up (ENV=dev)
+- make prod → make ENV=prod up
+- make logs streams aggregated service logs; make down stops services respecting ENV
+
+## On-demand migrations
+make migrate repeats the readiness check and runs the same Alembic upgrade in the backend container. Convenience wrappers exist: make migrate-dev and make migrate-prod.
+
+## Database lifecycle and preservation strategy
+- make reset-db: compose down -v, then start db fresh
+- make reset-db-dev / reset-db-prod: environment-specific wrappers
+- make reset-db-volume: removes only the Postgres data volume, then starts db to re-run init scripts
+  - Volume naming strategy:
+    - Project name PNAME is COMPOSE_PROJECT_NAME if set, else the basename of the repo directory
+    - Preserved DB volume name is PNAME_postgres_data
+- make clean-keep-db: removes containers and all project volumes except the DB volume, rebuilds frontend without cache, and restarts services
+
+## Database operations scripts
+- Backups: make db-backup runs ./db/backup.sh -e ENV
+- Restore: make db-restore FILE=path/to/backup.sql runs ./db/restore.sh -e ENV FILE
+- Maintenance: make db-maintenance CMD=stats runs ./db/maintenance.sh -e ENV CMD
+  - Supported maintenance commands: analyze, vacuum, stats, health, slow-queries, connections, size, all
+- Shell: make db-shell opens psql in the db container using POSTGRES_USER and POSTGRES_DB from the env file
+
+## Code quality and CI workflow
+- Linting: make lint → backend (Ruff) and frontend (ESLint)
+- Type checking: make type-check → backend (mypy with MYPYPATH=src and specific packages) and frontend (tsc)
+- Formatting: make format → backend (ruff format) and frontend (prettier)
+- Testing: make test runs backend (pytest) and frontend (npm test -- --run); make test-coverage runs backend coverage to terminal and HTML
+- Aggregate checks: make check runs lint, type-check, and check-migrations; make ci runs install, check, and test
+
+## Developer setup
+- make install installs backend deps via uv sync and frontend deps via npm ci
+- make dev-setup also installs pre-commit hooks in the backend container context
+- create-dev-user target executes the script inside the backend container to create an idempotent development user
+
+## File and path references
+- Alembic configuration: apps/backend/src/alembic.ini
+- Backend tests: apps/backend/tests/
+- DB scripts: db/backup.sh, db/restore.sh, db/maintenance.sh
+- Migration check script: scripts/check_migrations.sh
+
+Notes
+- Python commands are run inside containers via uv, ensuring toolchain consistency
+- Compose operations consistently pass both the env file and compose files, so manual docker compose commands should mimic that for parity

--- a/.kilocode/rules/memory-bank/brief.md
+++ b/.kilocode/rules/memory-bank/brief.md
@@ -1,0 +1,5 @@
+# Brief
+
+PantryPilot is an AI-assisted meal planning service that turns each user's own recipes into fast, personalized weekly meal plans and grocery guidance. Primary users: busy individuals and families. Core features: import/create recipes, capture preferences and dietary constraints, generate weekly plans with swaps, track cooked meals and leftovers, produce grocery lists, and respect time/budget constraints. Privacy stance: user-owned recipe data, authenticated access, and no sharing by default (opt-in only).
+
+Note: This file is owned by the user; Kilo Code may suggest improvements.

--- a/.kilocode/rules/memory-bank/context.md
+++ b/.kilocode/rules/memory-bank/context.md
@@ -1,0 +1,25 @@
+# Context
+
+## Current work focus
+Update the Memory Bank using the authoritative Makefile to accurately document development workflows, Docker Compose environment selection, database lifecycle operations, and cleanup commands.
+
+## Recent changes
+- Updated tech documentation with precise Make targets and behaviors based on the Makefile:
+  - Environment/Compose flows, migrations, installation, code quality, testing, convenience, database ops, and cleanup commands
+  - Added quick usage examples and tool notes
+  - File: [.kilocode/rules/memory-bank/tech.md](.kilocode/rules/memory-bank/tech.md)
+- Created architecture summary capturing runtime topology and critical flows:
+  - Env overlays: base + dev/prod compose files; .env.dev/.env.prod
+  - Startup flow: docker compose up -d; DB readiness via pg_isready; Alembic migrations via uv run
+  - DB lifecycle and preservation strategy, DB scripts, CI/quality flows, developer setup
+  - File: [.kilocode/rules/memory-bank/architecture.md](.kilocode/rules/memory-bank/architecture.md)
+
+## Next steps
+- Keep README, Makefile, and Memory Bank aligned; consider cross-linking key tasks in README to Memory Bank sections
+- Validate presence of referenced scripts and adjust docs if needed:
+  - [db/backup.sh](db/backup.sh), [db/restore.sh](db/restore.sh), [db/maintenance.sh](db/maintenance.sh), [scripts/check_migrations.sh](scripts/check_migrations.sh)
+- Optionally document repeatable maintenance workflows in tasks:
+  - Examples: reset-db-volume, clean-deps, clean-keep-db as task entries in [.kilocode/rules/memory-bank/tasks.md](.kilocode/rules/memory-bank/tasks.md)
+
+## Timestamp
+Updated: 2025-09-06

--- a/.kilocode/rules/memory-bank/memory-bank-instructions.md
+++ b/.kilocode/rules/memory-bank/memory-bank-instructions.md
@@ -1,0 +1,167 @@
+# Memory Bank
+
+I am an expert software engineer with a unique characteristic: my memory resets completely between sessions. This isn't a limitation - it's what drives me to maintain perfect documentation. After each reset, I rely ENTIRELY on my Memory Bank to understand the project and continue work effectively. I MUST read ALL memory bank files at the start of EVERY task - this is not optional. The memory bank files are located in `.kilocode/rules/memory-bank` folder.
+
+When I start a task, I will include `[Memory Bank: Active]` at the beginning of my response if I successfully read the memory bank files, or `[Memory Bank: Missing]` if the folder doesn't exist or is empty. If memory bank is missing, I will warn the user about potential issues and suggest initialization.
+
+## Memory Bank Structure
+
+The Memory Bank consists of core files and optional context files, all in Markdown format.
+
+### Core Files (Required)
+1. `brief.md`
+   This file is created and maintained manually by the developer. Don't edit this file directly but suggest to user to update it if it can be improved.
+   - Foundation document that shapes all other files
+   - Created at project start if it doesn't exist
+   - Defines core requirements and goals
+   - Source of truth for project scope
+
+2. `product.md`
+   - Why this project exists
+   - Problems it solves
+   - How it should work
+   - User experience goals
+
+3. `context.md`
+   This file should be short and factual, not creative or speculative.
+   - Current work focus
+   - Recent changes
+   - Next steps
+
+4. `architecture.md`
+   - System architecture
+   - Source Code paths
+   - Key technical decisions
+   - Design patterns in use
+   - Component relationships
+   - Critical implementation paths
+
+5. `tech.md`
+   - Technologies used
+   - Development setup
+   - Technical constraints
+   - Dependencies
+   - Tool usage patterns
+
+### Additional Files
+Create additional files/folders within memory-bank/ when they help organize:
+- `tasks.md` - Documentation of repetitive tasks and their workflows
+- Complex feature documentation
+- Integration specifications
+- API documentation
+- Testing strategies
+- Deployment procedures
+
+## Core workflows
+
+### Memory Bank Initialization
+
+The initialization step is CRITICALLY IMPORTANT and must be done with extreme thoroughness as it defines all future effectiveness of the Memory Bank. This is the foundation upon which all future interactions will be built.
+
+When user requests initialization of the memory bank (command `initialize memory bank`), I'll perform an exhaustive analysis of the project, including:
+- All source code files and their relationships
+- Configuration files and build system setup
+- Project structure and organization patterns
+- Documentation and comments
+- Dependencies and external integrations
+- Testing frameworks and patterns
+
+I must be extremely thorough during initialization, spending extra time and effort to build a comprehensive understanding of the project. A high-quality initialization will dramatically improve all future interactions, while a rushed or incomplete initialization will permanently limit my effectiveness.
+
+After initialization, I will ask the user to read through the memory bank files and verify product description, used technologies and other information. I should provide a summary of what I've understood about the project to help the user verify the accuracy of the memory bank files. I should encourage the user to correct any misunderstandings or add missing information, as this will significantly improve future interactions.
+
+### Memory Bank Update
+
+Memory Bank updates occur when:
+1. Discovering new project patterns
+2. After implementing significant changes
+3. When user explicitly requests with the phrase **update memory bank** (MUST review ALL files)
+4. When context needs clarification
+
+If I notice significant changes that should be preserved but the user hasn't explicitly requested an update, I should suggest: "Would you like me to update the memory bank to reflect these changes?"
+
+To execute Memory Bank update, I will:
+
+1. Review ALL project files
+2. Document current state
+3. Document Insights & Patterns
+4. If requested with additional context (e.g., "update memory bank using information from @/Makefile"), focus special attention on that source
+
+Note: When triggered by **update memory bank**, I MUST review every memory bank file, even if some don't require updates. Focus particularly on context.md as it tracks current state.
+
+### Add Task
+
+When user completes a repetitive task (like adding support for a new model version) and wants to document it for future reference, they can request: **add task** or **store this as a task**.
+
+This workflow is designed for repetitive tasks that follow similar patterns and require editing the same files. Examples include:
+- Adding support for new AI model versions
+- Implementing new API endpoints following established patterns
+- Adding new features that follow existing architecture
+
+Tasks are stored in the file `tasks.md` in the memory bank folder. The file is optional and can be empty. The file can store many tasks.
+
+To execute Add Task workflow:
+
+1. Create or update `tasks.md` in the memory bank folder
+2. Document the task with:
+   - Task name and description
+   - Files that need to be modified
+   - Step-by-step workflow followed
+   - Important considerations or gotchas
+   - Example of the completed implementation
+3. Include any context that was discovered during task execution but wasn't previously documented
+
+Example task entry:
+```markdown
+## Add New Model Support
+**Last performed:** [date]
+**Files to modify:**
+- `/providers/gemini.md` - Add model to documentation
+- `/src/providers/gemini-config.ts` - Add model configuration
+- `/src/constants/models.ts` - Add to model list
+- `/tests/providers/gemini.test.ts` - Add test cases
+
+**Steps:**
+1. Add model configuration with proper token limits
+2. Update documentation with model capabilities
+3. Add to constants file for UI display
+4. Write tests for new model configuration
+
+**Important notes:**
+- Check Google's documentation for exact token limits
+- Ensure backward compatibility with existing configurations
+- Test with actual API calls before committing
+```
+
+### Regular Task Execution
+
+In the beginning of EVERY task I MUST read ALL memory bank files - this is not optional.
+
+The memory bank files are located in `.kilocode/rules/memory-bank` folder. If the folder doesn't exist or is empty, I will warn user about potential issues with the memory bank. I will include `[Memory Bank: Active]` at the beginning of my response if I successfully read the memory bank files, or `[Memory Bank: Missing]` if the folder doesn't exist or is empty. If memory bank is missing, I will warn the user about potential issues and suggest initialization. I should briefly summarize my understanding of the project to confirm alignment with the user's expectations, like:
+
+"[Memory Bank: Active] I understand we're building a React inventory system with barcode scanning. Currently implementing the scanner component that needs to work with the backend API."
+
+When starting a task that matches a documented task in `tasks.md`, I should mention this and follow the documented workflow to ensure no steps are missed.
+
+If the task was repetitive and might be needed again, I should suggest: "Would you like me to add this task to the memory bank for future reference?"
+
+In the end of the task, when it seems to be completed, I will update `context.md` accordingly. If the change seems significant, I will suggest to the user: "Would you like me to update memory bank to reflect these changes?" I will not suggest updates for minor changes.
+
+## Context Window Management
+
+When the context window fills up during an extended session:
+1. I should suggest updating the memory bank to preserve the current state
+2. Recommend starting a fresh conversation/task
+3. In the new conversation, I will automatically load the memory bank files to maintain continuity
+
+## Technical Implementation
+
+Memory Bank is built on Kilo Code's Custom Rules feature, with files stored as standard markdown documents that both the user and I can access.
+
+## Important Notes
+
+REMEMBER: After every memory reset, I begin completely fresh. The Memory Bank is my only link to previous work. It must be maintained with precision and clarity, as my effectiveness depends entirely on its accuracy.
+
+If I detect inconsistencies between memory bank files, I should prioritize brief.md and note any discrepancies to the user.
+
+IMPORTANT: I MUST read ALL memory bank files at the start of EVERY task - this is not optional. The memory bank files are located in `.kilocode/rules/memory-bank` folder.

--- a/.kilocode/rules/memory-bank/tech.md
+++ b/.kilocode/rules/memory-bank/tech.md
@@ -1,0 +1,104 @@
+# Tech
+
+## Stacks and Versions
+- Backend (Python 3.12)
+  - FastAPI ≥ 0.116.1, Uvicorn/Gunicorn
+  - SQLAlchemy ≥ 2.x + asyncpg
+  - Alembic ≥ 1.16
+  - Auth: python-jose + Argon2
+  - Settings: pydantic-settings
+  - Dev/Test: pytest, pytest-asyncio, httpx, mypy, ruff
+  - Manifest: [pyproject.toml](apps/backend/pyproject.toml)
+- Frontend (TypeScript 5.8, Node ecosystem)
+  - React 19, React Router 7, Zustand 5
+  - Vite 7, Tailwind CSS 4
+  - Vitest 3 + Testing Library
+  - Manifest: [package.json](apps/frontend/package.json)
+- Infra/Tooling
+  - Dockerfiles for backend and frontend
+  - CI: Coverage to Codecov (see README)
+  - Linters/formatters: Ruff, mypy, ESLint, Prettier
+  - Configs: [apps/backend/mypy.ini](apps/backend/mypy.ini), [apps/frontend/.eslintrc.cjs](apps/frontend/.eslintrc.cjs), [apps/frontend/.prettierignore](apps/frontend/.prettierignore)
+
+## Dev Setup and Commands
+- Docker Compose and environments
+  - ENV selects environment: dev (default) or prod. Compose files: docker-compose.yml plus docker-compose.dev.yml or docker-compose.prod.yml; env file: .env.dev or .env.prod.
+  - make up runs docker compose up -d, waits for DB readiness (pg_isready), then applies Alembic migrations inside the backend container via uv run alembic -c /app/src/alembic.ini upgrade head.
+  - Aliases: dev is an alias for up; prod runs ENV=prod up. logs streams aggregated service logs; down respects ENV.
+- Make targets (grouped overview)
+  - Environment and Compose: validate-env, up, up-dev, up-prod, down, down-dev, down-prod, logs
+  - Database lifecycle: reset-db, reset-db-dev, reset-db-prod, reset-db-volume
+  - Database management: db-backup, db-restore FILE=..., db-maintenance CMD=..., db-shell
+  - Migrations: migrate, migrate-dev, migrate-prod, check-migrations (runs [check_migrations.sh](scripts/check_migrations.sh))
+  - Installation and setup: install, install-backend (uv sync), install-frontend (npm ci), dev-setup (uv run pre-commit install)
+  - Code quality: lint, lint-backend (uv run ruff check .), lint-frontend (npm run lint), type-check, type-check-backend (MYPYPATH=src uv run mypy -p api -p core -p crud -p dependencies -p models -p schemas), type-check-frontend (npm run type-check), format, format-backend (uv run ruff format .), format-frontend (npm run format), check, ci
+  - Testing: test, test-backend (uv run pytest), test-frontend (npm test -- --run), test-coverage (uv run pytest --cov=src --cov-report=term --cov-report=html)
+  - Convenience: dev, prod, create-dev-user (executes [create_dev_user.py](apps/backend/scripts/create_dev_user.py) inside backend container)
+- DB scripts and usage examples
+  - Backups: make db-backup
+  - Restore: make db-restore FILE=path/to/backup.sql
+  - Maintenance: make db-maintenance CMD=stats (available: analyze, vacuum, stats, health, slow-queries, connections, size, all)
+  - Shell: make db-shell to open psql against configured DB
+- Cleanup and maintenance
+  - clean: compose down --remove-orphans; clear caches in apps/backend and apps/frontend; remove dangling Docker images matching pantrypilot*.
+  - clean-deps: stop containers, remove frontend_node_modules and backend_cache volumes, rebuild frontend without cache, keep DB volume, then up -d.
+  - clean-build: full rebuild from scratch; prunes builder cache labeled project=pantrypilot, removes pantrypilot* images, rebuilds all.
+  - clean-all: down with volumes, remove all project volumes matching pantrypilot or frontend_node_modules, remove images/reference pantrypilot*, prune builder cache.
+  - clean-keep-db: preserves the Postgres data volume {COMPOSE_PROJECT_NAME or basename}_postgres_data while removing other project volumes; rebuilds frontend without cache; restarts services.
+- Tooling notes
+  - Python commands run inside containers using uv; Alembic config at [alembic.ini](apps/backend/src/alembic.ini).
+  - Frontend scripts live in [package.json](apps/frontend/package.json); backend test config in [pyproject.toml](apps/backend/pyproject.toml).
+- Quick commands
+  - make up
+  - make ENV=prod up
+  - make logs
+  - make ENV=prod logs
+  - make db-maintenance CMD=stats
+  - make clean-deps
+  - make clean-build
+
+## API and Auth
+- Base: /api/v1; documented in [docs/API_DESIGN.md](docs/API_DESIGN.md)
+- OAuth2 password flow; bearer JWTs
+  - Token creation: [create_access_token()](apps/backend/src/core/security.py:19)
+  - Token decoding: [decode_token()](apps/backend/src/core/security.py:51)
+  - Current user dependency: [get_current_user()](apps/backend/src/dependencies/auth.py:39)
+- Wrapped responses on most endpoints via ApiResponse
+
+## State, Routing, and Data Loading (Frontend)
+- Router and loaders: [routerConfig.tsx](apps/frontend/src/routerConfig.tsx)
+- Auth persistence and hydration flag: [useAuthStore](apps/frontend/src/stores/useAuthStore.ts)
+- API client and error handling: [api/client.ts](apps/frontend/src/api/client.ts)
+
+## Database and Migrations
+- Async engine/session dependency: [dependencies/db.py](apps/backend/src/dependencies/db.py)
+- Alembic environment: [alembic/env.py](apps/backend/src/alembic/env.py)
+- Representative migrations:
+  - Initial schema: [20250827_00_initial_schema.py](apps/backend/src/alembic/versions/20250827_00_initial_schema.py)
+  - Ownership/admin role: [20250905_05_add_user_ownership_and_admin_role.py](apps/backend/src/alembic/versions/20250905_05_add_user_ownership_and_admin_role.py)
+
+## Environment Variables (from [.env.example](.env.example))
+- DB
+  - POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB, POSTGRES_HOST, POSTGRES_PORT
+  - DATABASE_URL (backend uses asyncpg)
+- FastAPI
+  - ENVIRONMENT, SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
+  - API_V1_STR, PROJECT_NAME, VERSION
+- CORS
+  - CORS_ORIGINS (CSV or JSON array string)
+- Frontend
+  - VITE_API_URL (defaults to http://localhost:8000 in dev/test)
+- Ops
+  - COMPOSE_PROJECT_NAME, LOG_LEVEL, SENTRY_DSN (optional), CSP_* (prod)
+
+## Testing Strategy
+- Backend
+  - Unit/integration tests in [apps/backend/tests/](apps/backend/tests)
+  - pytest with asyncio and httpx clients; coverage gathered in CI
+- Frontend
+  - Vitest + Testing Library; jsdom environment
+  - Coverage via vitest V8 provider; see scripts in [package.json](apps/frontend/package.json)
+
+## External Integrations
+- None required at runtime beyond PostgreSQL
+- Sentry DSN placeholder in env template (TBD if used)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,29 @@ make down
 
 API versioning strategy: path-based under `/api/v1`. Swagger UI available at `/api/v1/docs`.
 
+## API Endpoints
+
+### User Registration
+
+Register a new user account with the registration endpoint:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "newuser123",
+    "email": "newuser123@example.com",
+    "password": "averylongsecurepw",
+    "first_name": "New",
+    "last_name": "User"
+  }'
+```
+
+Expected 201 response:
+```json
+{ "access_token": "...", "token_type": "bearer" }
+```
+
 Database migrations: Alembic configured; run `make migrate` or applied on `make up` after DB is healthy.
 
 Frontend/backed commands:

--- a/apps/backend/mypy.ini
+++ b/apps/backend/mypy.ini
@@ -14,8 +14,34 @@ follow_imports = normal
 # Limit files to the src folder to avoid checking other workspace files.
 files = src
 
-# Exclude test and script paths even when a broad CLI target (".") is passed
-exclude = ^tests/|^scripts/
+# Exclude test and script paths even when a broad CLI target (".") is passed.
+# Use a more flexible regex so the pattern matches whether mypy is run from
+# the repo root or from `apps/backend` (CI/Makefile runs `cd apps/backend`).
+# Matches paths like 'tests/', './tests/', 'apps/backend/tests/', etc.
+exclude = (^|/)(tests|scripts)/
 
 # Target Python version for accurate builtin types and stubs
 python_version = 3.12
+
+# NOTE:
+# The repository also contains `[tool.mypy]` settings in `pyproject.toml`.
+# By default mypy searches for config files in the current working directory
+# and will pick the first one it finds (e.g. `mypy.ini` in `apps/backend`).
+# The Makefile runs mypy from `apps/backend` (see `make type-check-backend`),
+# so this file is the effective configuration during CI/local `make` runs.
+# To keep behavior consistent, we enable the same "strict" flags here that
+# are declared in `pyproject.toml`.
+
+# Strictness flags (mirrors `[tool.mypy]` in pyproject.toml)
+check_untyped_defs = True
+disallow_any_generics = True
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+no_implicit_optional = True
+no_implicit_reexport = True
+strict_equality = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unreachable = True
+warn_unused_configs = True
+warn_unused_ignores = True

--- a/apps/backend/mypy.ini
+++ b/apps/backend/mypy.ini
@@ -1,7 +1,9 @@
 [mypy]
-# Make the current directory (apps/backend) part of mypy's search path so
-# the `src` package is importable as `src.*` during type checks.
-mypy_path = .
+# Ensure mypy can resolve top-level packages (core, models, etc.) located under ./src
+mypy_path = ./src
+
+# Avoid duplicate module discovery between "." (which exposes "src.*") and "./src"
+explicit_package_bases = True
 
 # Enable namespace packages in case the project uses them.
 namespace_packages = True
@@ -11,6 +13,9 @@ follow_imports = normal
 
 # Limit files to the src folder to avoid checking other workspace files.
 files = src
+
+# Exclude test and script paths even when a broad CLI target (".") is passed
+exclude = ^tests/|^scripts/
 
 # Target Python version for accurate builtin types and stubs
 python_version = 3.12

--- a/apps/backend/src/api/v1/recipes.py
+++ b/apps/backend/src/api/v1/recipes.py
@@ -29,6 +29,7 @@ from models.recipes_names import Recipe
 from models.users import User
 from schemas.api import ApiResponse
 from schemas.recipes import (
+    IngredientIn,
     RecipeCategory,
     RecipeCreate,
     RecipeDifficulty,
@@ -360,7 +361,10 @@ async def _get_or_create_ingredient(
 
 
 async def _replace_recipe_ingredients(
-    db: AsyncSession, recipe: Recipe, ingredients_data: list, user_id: UUIDType
+    db: AsyncSession,
+    recipe: Recipe,
+    ingredients_data: list[IngredientIn],
+    user_id: UUIDType,
 ) -> list[RecipeIngredient]:
     """Replace all ingredient associations for a recipe with new ones.
 

--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -83,4 +83,8 @@ def get_settings() -> Settings:
     # Provide safe fallbacks for tests if env file is absent.
     if not os.path.exists(env_file):  # pragma: no cover - defensive
         os.environ.setdefault("SECRET_KEY", "dev-test-secret")
+    # The Settings initializer accepts a runtime-only `_env_file` kwarg used by
+    # pydantic-settings; mypy's stub doesn't allow this call argument. The
+    # ignore is scoped to the specific `call-arg` error to avoid hiding other
+    # issues.
     return Settings(_env_file=env_file)  # type: ignore[call-arg]

--- a/apps/backend/src/dependencies/db.py
+++ b/apps/backend/src/dependencies/db.py
@@ -21,16 +21,15 @@ from sqlalchemy.ext.asyncio import (
 )
 
 
-# Best-effort load of env files for local dev (optional dependency)
-try:  # pragma: no cover - optional convenience for local runs
-    from dotenv import load_dotenv  # type: ignore
-except Exception:  # pragma: no cover
-    load_dotenv = None  # type: ignore[assignment]
-
-
 def _load_env_files() -> None:  # pragma: no cover - side-effect only
-    if load_dotenv is None:
+    # Import dotenv lazily so the module is optional for users who don't
+    # need to load env files. This avoids module-level side effects and
+    # keeps mypy from assuming the symbol is always defined.
+    try:  # pragma: no cover - optional convenience for local runs
+        from dotenv import load_dotenv
+    except ImportError:  # pragma: no cover
         return
+
     # Try to load .env then .env.dev from repo root or any parent directory
     for fname in (".env", ".env.dev"):
         for p in Path(__file__).resolve().parents:

--- a/apps/backend/src/models/__init__.py
+++ b/apps/backend/src/models/__init__.py
@@ -1,3 +1,10 @@
+"""Expose commonly used ORM models at package level.
+
+These re-exports are intentional so callers can import from
+``models`` (e.g. `from models import User`). The `F401` noqa suppresses
+unused-import warnings for the explicit re-exports.
+"""
+
 from .ingredient_names import Ingredient  # noqa: F401
 from .meal_history import Meal  # noqa: F401
 from .recipe_ingredients import RecipeIngredient  # noqa: F401

--- a/apps/backend/src/models/recipe_ingredients.py
+++ b/apps/backend/src/models/recipe_ingredients.py
@@ -27,6 +27,8 @@ class RecipeIngredient(Base):
     ingredient_id = Column(
         UUID(as_uuid=True), ForeignKey("ingredient_names.id"), nullable=False
     )  # noqa: E501
+    # Long SQLAlchemy column definition above is clearer on one line; E501
+    # (line-length) is suppressed intentionally to avoid awkward wrapping.
     quantity_value = Column(Numeric, nullable=True)
     quantity_unit = Column(String(64), nullable=True)
     prep = Column(JSONB, nullable=False, server_default="{}")

--- a/apps/backend/src/schemas/auth.py
+++ b/apps/backend/src/schemas/auth.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 
 
 class Token(BaseModel):
@@ -22,3 +22,27 @@ class LoginResponse(Token):
 
     user_id: str = Field(..., description="Unique identifier for the user")
     email: str = Field(..., description="Email of the authenticated user")
+
+
+class UserRegister(BaseModel):
+    """Schema for user registration."""
+
+    username: str = Field(
+        ...,
+        min_length=3,
+        max_length=32,
+        pattern=r"^[a-zA-Z0-9_\-]{3,32}$",
+        description="Username (3-32 chars, alphanumeric, underscore, hyphen)",
+    )
+    email: EmailStr = Field(..., description="Valid email address")
+    password: str = Field(
+        ...,
+        min_length=12,
+        description="Password with minimum length of 12 characters",
+    )
+    first_name: str | None = Field(
+        default=None, max_length=50, description="Optional first name"
+    )
+    last_name: str | None = Field(
+        default=None, max_length=50, description="Optional last name"
+    )

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -8,6 +8,7 @@ external .env file during tests.
 import os
 import uuid
 from collections.abc import AsyncGenerator, Generator
+from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
@@ -127,3 +128,29 @@ async def async_client() -> AsyncGenerator[AsyncClient, None]:
         yield client
     app.dependency_overrides.pop(get_db, None)
     app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture
+def payload_namespace():
+    """Factory fixture that builds SimpleNamespace-like payloads for unit tests.
+
+    Use this in unit tests that directly call route functions to bypass Pydantic
+    validation and exercise manual branches.
+    """
+
+    def _make(
+        username: str = "testuser",
+        email: str = "test@test.com",
+        password: str = "securepassword123",
+        first_name: str | None = None,
+        last_name: str | None = None,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            username=username,
+            email=email,
+            password=password,
+            first_name=first_name,
+            last_name=last_name,
+        )
+
+    return _make

--- a/apps/backend/tests/test_auth_register.py
+++ b/apps/backend/tests/test_auth_register.py
@@ -226,30 +226,30 @@ async def test_register_password_too_short(
 
 
 @pytest.mark.asyncio
-async def test_register_password_various_short_lengths(
-    auth_client: tuple[AsyncClient, AsyncSession],
-):
-    """Test passwords of various short lengths all return 400."""
-    client, _ = auth_client
-
-    short_passwords = [
+@pytest.mark.parametrize(
+    "password",
+    [
         "short",  # 5 characters
         "password10",  # 10 characters
         "password11",  # 11 characters
-    ]
+    ],
+)
+async def test_register_password_various_short_lengths(
+    auth_client: tuple[AsyncClient, AsyncSession], password: str
+):
+    client, _ = auth_client
 
-    for i, password in enumerate(short_passwords):
-        registration_data = {
-            "username": f"testuser{i}",
-            "email": f"test{i}@test.com",
-            "password": password,
-        }
+    registration_data = {
+        "username": "testuser",
+        "email": "test@test.com",
+        "password": password,
+    }
 
-        resp = await client.post("/api/v1/auth/register", json=registration_data)
+    resp = await client.post("/api/v1/auth/register", json=registration_data)
 
-        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-        # Pydantic validation error for min_length constraint
-        assert "detail" in resp.json()
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    # Pydantic validation error for min_length constraint
+    assert "detail" in resp.json()
 
 
 @pytest.mark.asyncio
@@ -298,59 +298,59 @@ async def test_register_invalid_email(auth_client: tuple[AsyncClient, AsyncSessi
 
 
 @pytest.mark.asyncio
-async def test_register_invalid_username_pattern(
-    auth_client: tuple[AsyncClient, AsyncSession],
-):
-    """Test username not matching pattern returns 422."""
-    client, _ = auth_client
-
-    invalid_usernames = [
+@pytest.mark.parametrize(
+    "username",
+    [
         "ab",  # Too short (< 3 chars)
         "a" * 33,  # Too long (> 32 chars)
         "user@name",  # Contains invalid character (@)
         "user name",  # Contains space
         "user.name",  # Contains period
-    ]
+    ],
+)
+async def test_register_invalid_username_pattern(
+    auth_client: tuple[AsyncClient, AsyncSession], username: str
+):
+    client, _ = auth_client
 
-    for i, username in enumerate(invalid_usernames):
-        registration_data = {
-            "username": username,
-            "email": f"test{i}@test.com",
-            "password": "securepassword123",
-        }
+    registration_data = {
+        "username": username,
+        "email": "test@test.com",
+        "password": "securepassword123",
+    }
 
-        resp = await client.post("/api/v1/auth/register", json=registration_data)
+    resp = await client.post("/api/v1/auth/register", json=registration_data)
 
-        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
-async def test_register_valid_username_patterns(
-    auth_client: tuple[AsyncClient, AsyncSession],
-):
-    """Test valid username patterns are accepted."""
-    client, _ = auth_client
-
-    valid_usernames = [
+@pytest.mark.parametrize(
+    "username",
+    [
         "abc",  # Minimum length (3 chars)
         "a" * 32,  # Maximum length (32 chars)
         "user_name",  # Contains underscore
         "user-name",  # Contains hyphen
         "user123",  # Contains numbers
         "User123",  # Contains uppercase
-    ]
+    ],
+)
+async def test_register_valid_username_patterns(
+    auth_client: tuple[AsyncClient, AsyncSession], username: str
+):
+    client, _ = auth_client
 
-    for i, username in enumerate(valid_usernames):
-        registration_data = {
-            "username": username,
-            "email": f"valid{i}@test.com",
-            "password": "securepassword123",
-        }
+    registration_data = {
+        "username": username,
+        "email": "valid@test.com",
+        "password": "securepassword123",
+    }
 
-        resp = await client.post("/api/v1/auth/register", json=registration_data)
+    resp = await client.post("/api/v1/auth/register", json=registration_data)
 
-        # Should succeed (not 422)
-        assert resp.status_code == status.HTTP_201_CREATED
+    # Should succeed (not 422)
+    assert resp.status_code == status.HTTP_201_CREATED
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/test_auth_register.py
+++ b/apps/backend/tests/test_auth_register.py
@@ -1,0 +1,620 @@
+"""Registration endpoint tests for PantryPilot.
+
+Covers:
+- Successful registration returns token and creates user
+- Password validation (minimum 12 characters)
+- Duplicate username/email handling
+- Token usability after registration
+- Input validation for username, email, and required fields
+- Password hashing verification
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from fastapi import status
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from core.config import get_settings
+from core.security import verify_password
+from dependencies.auth import get_current_user
+from dependencies.db import get_db
+from main import app
+from models.base import Base
+from models.meal_history import Meal
+from models.users import User
+
+
+settings = get_settings()
+
+
+@pytest_asyncio.fixture
+async def auth_client() -> AsyncGenerator[tuple[AsyncClient, AsyncSession], None]:
+    """Client + real in-memory SQLite DB with full schema for auth tests.
+
+    Removes any auth override so routes are actually protected.
+    """
+    # Ensure no auth override from generic fixtures
+    app.dependency_overrides.pop(get_current_user, None)
+
+    engine: AsyncEngine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", future=True
+    )
+    async with engine.begin() as conn:
+        # Create minimal subset of tables to satisfy auth & mealplans tests.
+        # Avoid Recipe model (Postgres ARRAY) which SQLite can't compile.
+        await conn.exec_driver_sql(
+            "CREATE TABLE IF NOT EXISTS recipe_names (id BLOB PRIMARY KEY)"
+        )
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn, tables=[User.__table__, Meal.__table__]
+            )
+        )
+
+    SessionLocal = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+
+    async def _override_get_db():
+        async with SessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        async with SessionLocal() as session:
+            yield c, session
+    app.dependency_overrides.pop(get_db, None)
+    await engine.dispose()
+
+
+async def _create_existing_user(
+    db: AsyncSession, username: str = "existing", email: str = "existing@test.com"
+) -> User:
+    """Create an existing user for duplicate testing."""
+    user = User(
+        username=username,
+        email=email,
+        hashed_password="hashed_password_placeholder",
+        first_name="Existing",
+        last_name="User",
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+@pytest.mark.asyncio
+async def test_register_success(auth_client: tuple[AsyncClient, AsyncSession]):
+    """Test successful registration with valid data."""
+    client, db = auth_client
+
+    registration_data = {
+        "username": "newuser123",
+        "email": "newuser@test.com",
+        "password": "securepassword123",
+        "first_name": "New",
+        "last_name": "User",
+    }
+
+    resp = await client.post("/api/v1/auth/register", json=registration_data)
+
+    # Verify 201 status code
+    assert resp.status_code == status.HTTP_201_CREATED
+
+    # Verify response contains access_token and token_type
+    payload = resp.json()
+    assert "access_token" in payload
+    assert payload["access_token"]
+    assert payload["token_type"] == "bearer"
+
+    # Verify user is created in database
+    result = await db.execute(select(User).where(User.username == "newuser123"))
+    created_user = result.scalar_one_or_none()
+    assert created_user is not None
+    assert created_user.username == "newuser123"
+    assert created_user.email == "newuser@test.com"
+    assert created_user.first_name == "New"
+    assert created_user.last_name == "User"
+
+    # Verify password is properly hashed (not stored as plaintext)
+    assert created_user.hashed_password != "securepassword123"
+    assert verify_password("securepassword123", created_user.hashed_password)
+
+
+@pytest.mark.asyncio
+async def test_register_success_minimal_data(
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """Test successful registration with only required fields."""
+    client, db = auth_client
+
+    registration_data = {
+        "username": "minimaluser",
+        "email": "minimal@test.com",
+        "password": "anothersecurepassword",
+    }
+
+    resp = await client.post("/api/v1/auth/register", json=registration_data)
+
+    assert resp.status_code == status.HTTP_201_CREATED
+    payload = resp.json()
+    assert payload["access_token"]
+    assert payload["token_type"] == "bearer"
+
+    # Verify user is created with optional fields as None
+    result = await db.execute(select(User).where(User.username == "minimaluser"))
+    created_user = result.scalar_one_or_none()
+    assert created_user is not None
+    assert created_user.first_name is None
+    assert created_user.last_name is None
+
+
+@pytest.mark.asyncio
+async def test_register_duplicate_username(
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """Test duplicate username returns 409."""
+    client, db = auth_client
+
+    # Create existing user
+    await _create_existing_user(db, username="duplicateuser", email="first@test.com")
+
+    registration_data = {
+        "username": "duplicateuser",  # Same username
+        "email": "different@test.com",  # Different email
+        "password": "securepassword123",
+    }
+
+    resp = await client.post("/api/v1/auth/register", json=registration_data)
+
+    assert resp.status_code == status.HTTP_409_CONFLICT
+    assert resp.json()["detail"] == "Username or email already exists"
+
+
+@pytest.mark.asyncio
+async def test_register_duplicate_email(auth_client: tuple[AsyncClient, AsyncSession]):
+    """Test duplicate email returns 409."""
+    client, db = auth_client
+
+    # Create existing user
+    await _create_existing_user(db, username="firstuser", email="duplicate@test.com")
+
+    registration_data = {
+        "username": "differentuser",  # Different username
+        "email": "duplicate@test.com",  # Same email
+        "password": "securepassword123",
+    }
+
+    resp = await client.post("/api/v1/auth/register", json=registration_data)
+
+    assert resp.status_code == status.HTTP_409_CONFLICT
+    assert resp.json()["detail"] == "Username or email already exists"
+
+
+@pytest.mark.asyncio
+async def test_register_password_too_short(
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """Test password < 12 chars returns 400."""
+    client, _ = auth_client
+
+    # Test with 11 characters
+    registration_data = {
+        "username": "testuser",
+        "email": "test@test.com",
+        "password": "short11char",  # 11 characters
+    }
+
+    resp = await client.post("/api/v1/auth/register", json=registration_data)
+
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    # Pydantic validation error for min_length constraint
+    assert "detail" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_register_password_various_short_lengths(
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """Test passwords of various short lengths all return 400."""
+    client, _ = auth_client
+
+    short_passwords = [
+        "short",  # 5 characters
+        "password10",  # 10 characters
+        "password11",  # 11 characters
+    ]
+
+    for i, password in enumerate(short_passwords):
+        registration_data = {
+            "username": f"testuser{i}",
+            "email": f"test{i}@test.com",
+            "password": password,
+        }
+
+        resp = await client.post("/api/v1/auth/register", json=registration_data)
+
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        # Pydantic validation error for min_length constraint
+        assert "detail" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_register_token_grants_access(
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """Test returned token works on protected endpoint."""
+    client, _ = auth_client
+
+    registration_data = {
+        "username": "tokenuser",
+        "email": "token@test.com",
+        "password": "securepassword123",
+    }
+
+    # Register user and get token
+    resp = await client.post("/api/v1/auth/register", json=registration_data)
+    assert resp.status_code == status.HTTP_201_CREATED
+
+    token = resp.json()["access_token"]
+
+    # Use token to access protected endpoint
+    protected_resp = await client.get(
+        "/api/v1/mealplans/weekly?start=2025-01-14",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Should not be unauthorized (token works)
+    assert protected_resp.status_code != status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_register_invalid_email(auth_client: tuple[AsyncClient, AsyncSession]):
+    """Test invalid email format returns 422."""
+    client, _ = auth_client
+
+    registration_data = {
+        "username": "testuser",
+        "email": "not-an-email",  # Invalid email format
+        "password": "securepassword123",
+    }
+
+    resp = await client.post("/api/v1/auth/register", json=registration_data)
+
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_register_invalid_username_pattern(
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """Test username not matching pattern returns 422."""
+    client, _ = auth_client
+
+    invalid_usernames = [
+        "ab",  # Too short (< 3 chars)
+        "a" * 33,  # Too long (> 32 chars)
+        "user@name",  # Contains invalid character (@)
+        "user name",  # Contains space
+        "user.name",  # Contains period
+    ]
+
+    for i, username in enumerate(invalid_usernames):
+        registration_data = {
+            "username": username,
+            "email": f"test{i}@test.com",
+            "password": "securepassword123",
+        }
+
+        resp = await client.post("/api/v1/auth/register", json=registration_data)
+
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_register_valid_username_patterns(
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """Test valid username patterns are accepted."""
+    client, _ = auth_client
+
+    valid_usernames = [
+        "abc",  # Minimum length (3 chars)
+        "a" * 32,  # Maximum length (32 chars)
+        "user_name",  # Contains underscore
+        "user-name",  # Contains hyphen
+        "user123",  # Contains numbers
+        "User123",  # Contains uppercase
+    ]
+
+    for i, username in enumerate(valid_usernames):
+        registration_data = {
+            "username": username,
+            "email": f"valid{i}@test.com",
+            "password": "securepassword123",
+        }
+
+        resp = await client.post("/api/v1/auth/register", json=registration_data)
+
+        # Should succeed (not 422)
+        assert resp.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.asyncio
+async def test_register_missing_required_fields(
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """Test missing username/email/password returns 422."""
+    client, _ = auth_client
+
+    # Missing username
+    resp = await client.post(
+        "/api/v1/auth/register",
+        json={"email": "test@test.com", "password": "securepassword123"},
+    )
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    # Missing email
+    resp = await client.post(
+        "/api/v1/auth/register",
+        json={"username": "testuser", "password": "securepassword123"},
+    )
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    # Missing password
+    resp = await client.post(
+        "/api/v1/auth/register", json={"username": "testuser", "email": "test@test.com"}
+    )
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_register_email_normalization(
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """Test email is normalized to lowercase."""
+    client, db = auth_client
+
+    registration_data = {
+        "username": "normalizeuser",
+        "email": "UPPERCASE@TEST.COM",  # Uppercase email
+        "password": "securepassword123",
+    }
+
+    resp = await client.post("/api/v1/auth/register", json=registration_data)
+    assert resp.status_code == status.HTTP_201_CREATED
+
+    # Verify email is stored in lowercase
+    result = await db.execute(select(User).where(User.username == "normalizeuser"))
+    created_user = result.scalar_one_or_none()
+    assert created_user is not None
+    assert created_user.email == "uppercase@test.com"  # Should be lowercase
+
+
+@pytest.mark.asyncio
+async def test_register_password_exactly_12_chars(
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """Test password with exactly 12 characters is accepted."""
+    client, _ = auth_client
+
+    registration_data = {
+        "username": "exactuser",
+        "email": "exact@test.com",
+        "password": "exactly12chr",  # Exactly 12 characters
+    }
+
+    resp = await client.post("/api/v1/auth/register", json=registration_data)
+
+    assert resp.status_code == status.HTTP_201_CREATED
+    payload = resp.json()
+    assert payload["access_token"]
+    assert payload["token_type"] == "bearer"
+
+
+@pytest.mark.asyncio
+async def test_register_password_too_short_internal_validation_unit(
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """
+    Unit-level test that directly invokes the register() endpoint function to
+    cover the manual password-length check path (len(payload.password) < 12),
+    which is bypassed by FastAPI/Pydantic validation in HTTP tests.
+
+    This ensures coverage for the error handling branch that raises HTTP 400
+    with detail 'Password too short'.
+    """
+    # Import locally to avoid modifying module-level imports and keep the test isolated
+    from types import SimpleNamespace
+
+    from fastapi import HTTPException, status  # type: ignore
+
+    from api.v1.auth import register  # type: ignore
+
+    _, db = auth_client  # We only need the DB session, not the client
+
+    # Create a minimal payload-like object that bypasses Pydantic validation
+    # so we can hit the manual password length branch inside the route function.
+    payload = SimpleNamespace(
+        username="unitshort",
+        email="UNIT@EXAMPLE.COM",  # upper-case to also execute normalization code
+        password="short",  # < 12 characters to trigger the manual 400 path
+        first_name="Unit",
+        last_name="Test",
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await register(payload, db)
+
+    assert excinfo.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert excinfo.value.detail == "Password too short"
+
+    # Ensure no user was created in the database
+    result = await db.execute(select(User).where(User.username == "unitshort"))
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_register_duplicate_user_error_unit(
+    monkeypatch: pytest.MonkeyPatch,
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """
+    Unit-level test to force DuplicateUserError from create_user to cover the
+    register() exception path (HTTP 409) explicitly.
+    """
+    from types import SimpleNamespace
+
+    from fastapi import HTTPException, status  # type: ignore
+
+    import api.v1.auth as auth_mod  # type: ignore
+    from core.exceptions import DuplicateUserError  # type: ignore
+
+    # Patch the dependencies in the module under test
+    monkeypatch.setattr(auth_mod, "get_password_hash", lambda pw: "hashed_pw")
+
+    async def _raise_duplicate(*args, **kwargs):
+        raise DuplicateUserError()
+
+    monkeypatch.setattr(auth_mod, "create_user", _raise_duplicate)
+
+    _, db = auth_client
+
+    payload = SimpleNamespace(
+        username="dupeuser",
+        email="dupe@EXAMPLE.COM",
+        password="longenoughpassword",
+        first_name=None,
+        last_name=None,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await auth_mod.register(payload, db)
+
+    assert excinfo.value.status_code == status.HTTP_409_CONFLICT
+    assert excinfo.value.detail == "Username or email already exists"
+
+
+@pytest.mark.asyncio
+async def test_register_success_unit_token_path(
+    monkeypatch: pytest.MonkeyPatch,
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """
+    Unit-level success test that mocks create_user and create_access_token
+    to ensure the token creation/return lines are covered in register().
+    """
+    import uuid
+    from types import SimpleNamespace
+
+    import api.v1.auth as auth_mod  # type: ignore
+
+    # Patch hashing and token creation
+    monkeypatch.setattr(auth_mod, "get_password_hash", lambda pw: "hashed_pw")
+    monkeypatch.setattr(auth_mod, "create_access_token", lambda data: "unit-token")
+
+    class _DummyUser:
+        def __init__(self):
+            self.id = uuid.uuid4()
+
+    async def _fake_create_user(*args, **kwargs):
+        return _DummyUser()
+
+    monkeypatch.setattr(auth_mod, "create_user", _fake_create_user)
+
+    _, db = auth_client
+    payload = SimpleNamespace(
+        username="unitok",
+        email="UNITOK@EXAMPLE.COM",  # also exercises email normalization
+        password="longenoughpassword",
+        first_name=None,
+        last_name=None,
+    )
+
+    token = await auth_mod.register(payload, db)
+    assert token.access_token == "unit-token"
+    assert token.token_type == "bearer"
+
+
+@pytest.mark.asyncio
+async def test_login_invalid_credentials_unit(
+    monkeypatch: pytest.MonkeyPatch,
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """
+    Unit-level test for login() invalid credentials path to cover lines 28-36
+    in [api.v1.auth](apps/backend/src/api/v1/auth.py:1). Ensures 401 is raised.
+    """
+    from types import SimpleNamespace
+
+    from fastapi import HTTPException, status  # type: ignore
+
+    import api.v1.auth as auth_mod  # type: ignore
+
+    # Force get_user_by_username to return no user
+    async def _no_user(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(auth_mod, "get_user_by_username", _no_user)
+
+    _, db = auth_client
+    form = SimpleNamespace(username="nouser", password="badpass")
+
+    with pytest.raises(HTTPException) as excinfo:
+        await auth_mod.login(form, db)
+
+    assert excinfo.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert excinfo.value.detail == "Incorrect username or password"
+
+
+@pytest.mark.asyncio
+async def test_login_success_unit(
+    monkeypatch: pytest.MonkeyPatch,
+    auth_client: tuple[AsyncClient, AsyncSession],
+):
+    """
+    Unit-level test for login() success path to cover token creation lines
+    in [api.v1.auth](apps/backend/src/api/v1/auth.py:1). Returns a deterministic token.
+    """
+    import uuid
+    from types import SimpleNamespace
+
+    import api.v1.auth as auth_mod  # type: ignore
+
+    # Deterministic token generation
+    monkeypatch.setattr(
+        auth_mod,
+        "create_access_token",
+        lambda data: "unit-login-token",
+    )
+
+    # Build a dummy user with a valid hashed password
+    class _DummyUser:
+        def __init__(self):
+            self.id = uuid.uuid4()
+            self.hashed_password = auth_mod.get_password_hash("goodpass")
+
+    async def _user_ok(db, username: str):
+        return _DummyUser()
+
+    monkeypatch.setattr(auth_mod, "get_user_by_username", _user_ok)
+
+    _, db = auth_client
+    form = SimpleNamespace(username="dummy", password="goodpass")
+
+    token = await auth_mod.login(form, db)
+    assert token.access_token == "unit-login-token"
+    assert token.token_type == "bearer"

--- a/apps/frontend/eslint.config.js
+++ b/apps/frontend/eslint.config.js
@@ -5,6 +5,12 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import globals from 'globals';
 
+// Provide a minimal structuredClone polyfill for environments where it's missing (e.g. some Node runtimes).
+// This affects only the ESLint process and does not impact application/runtime code.
+if (typeof globalThis.structuredClone !== 'function') {
+  globalThis.structuredClone = (obj) => JSON.parse(JSON.stringify(obj));
+}
+
 // Flat ESLint config using @typescript-eslint recommendedTypeChecked configs
 export default [
   {
@@ -52,7 +58,7 @@ export default [
       // disable core rule and let typescript-eslint handle it
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': [
-        'warn',
+        'error',
         {
           varsIgnorePattern: '^_',
           argsIgnorePattern: '^_',

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -12,7 +12,7 @@
     "format:check": "prettier --check .",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:coverage": "vitest --coverage",
+    "test:coverage": "NODE_OPTIONS=--experimental-global-webcrypto vitest --coverage",
     "preview": "vite preview",
     "prepare": "husky"
   },

--- a/apps/frontend/src/api/__tests__/auth.test.ts
+++ b/apps/frontend/src/api/__tests__/auth.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { login } from '../endpoints/auth';
-import type { LoginFormData } from '../../types/auth';
+import { login, register } from '../endpoints/auth';
+import type { LoginFormData, RegisterFormData } from '../../types/Auth';
 
 describe('Auth API', () => {
   const fetchMock = vi.fn();
@@ -92,6 +92,222 @@ describe('Auth API', () => {
     await expect(login(formData)).rejects.toMatchObject({
       message: 'Request failed (500)',
       status: 500,
+    });
+  });
+});
+
+describe('Register API', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('handles successful registration', async () => {
+    const mockToken = {
+      access_token: 'test-registration-token',
+      token_type: 'bearer' as const,
+    };
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      text: vi.fn().mockResolvedValue(JSON.stringify(mockToken)),
+    });
+
+    const formData: RegisterFormData = {
+      username: 'newuser',
+      email: 'newuser@example.com',
+      password: 'securepassword123',
+      confirmPassword: 'securepassword123',
+      first_name: 'John',
+      last_name: 'Doe',
+    };
+
+    const result = await register(formData);
+
+    expect(result).toEqual(mockToken);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/auth/register'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          username: 'newuser',
+          email: 'newuser@example.com',
+          password: 'securepassword123',
+          first_name: 'John',
+          last_name: 'Doe',
+          // confirmPassword should be excluded
+        }),
+      })
+    );
+  });
+
+  it('excludes confirmPassword from request body', async () => {
+    const mockToken = {
+      access_token: 'test-token',
+      token_type: 'bearer' as const,
+    };
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      text: vi.fn().mockResolvedValue(JSON.stringify(mockToken)),
+    });
+
+    const formData: RegisterFormData = {
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'password123456',
+      confirmPassword: 'password123456',
+    };
+
+    await register(formData);
+
+    const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(requestBody).not.toHaveProperty('confirmPassword');
+    expect(requestBody).toEqual({
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'password123456',
+    });
+  });
+
+  it('handles registration failure with 400 error (validation error)', async () => {
+    const validationError = {
+      detail: 'Username already exists',
+    };
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: vi.fn().mockResolvedValue(JSON.stringify(validationError)),
+    });
+
+    const formData: RegisterFormData = {
+      username: 'existinguser',
+      email: 'test@example.com',
+      password: 'password123456',
+      confirmPassword: 'password123456',
+    };
+
+    await expect(register(formData)).rejects.toMatchObject({
+      message: 'Username already exists',
+      status: 400,
+    });
+  });
+
+  it('handles registration failure with 409 error (conflict)', async () => {
+    const conflictError = {
+      detail: 'Email already registered',
+    };
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      text: vi.fn().mockResolvedValue(JSON.stringify(conflictError)),
+    });
+
+    const formData: RegisterFormData = {
+      username: 'newuser',
+      email: 'existing@example.com',
+      password: 'password123456',
+      confirmPassword: 'password123456',
+    };
+
+    await expect(register(formData)).rejects.toMatchObject({
+      message: 'Email already registered',
+      status: 409,
+    });
+  });
+
+  it('handles registration failure with 422 error (unprocessable entity)', async () => {
+    const validationError = {
+      detail: [
+        {
+          loc: ['body', 'email'],
+          msg: 'field required',
+          type: 'value_error.missing',
+        },
+      ],
+    };
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      text: vi.fn().mockResolvedValue(JSON.stringify(validationError)),
+    });
+
+    const formData: RegisterFormData = {
+      username: 'testuser',
+      email: '',
+      password: 'password123456',
+      confirmPassword: 'password123456',
+    };
+
+    await expect(register(formData)).rejects.toMatchObject({
+      status: 422,
+    });
+  });
+
+  it('handles network errors', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('Network error'));
+
+    const formData: RegisterFormData = {
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'password123456',
+      confirmPassword: 'password123456',
+    };
+
+    await expect(register(formData)).rejects.toThrow('Network error');
+  });
+
+  it('handles server errors with generic message', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue(JSON.stringify({})),
+    });
+
+    const formData: RegisterFormData = {
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'password123456',
+      confirmPassword: 'password123456',
+    };
+
+    await expect(register(formData)).rejects.toMatchObject({
+      message: 'Request failed (500)',
+      status: 500,
+    });
+  });
+
+  it('handles error responses with message field instead of detail', async () => {
+    const errorWithMessage = {
+      message: 'Custom registration error',
+    };
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: vi.fn().mockResolvedValue(JSON.stringify(errorWithMessage)),
+    });
+
+    const formData: RegisterFormData = {
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'password123456',
+      confirmPassword: 'password123456',
+    };
+
+    await expect(register(formData)).rejects.toMatchObject({
+      message: 'Custom registration error',
+      status: 400,
     });
   });
 });

--- a/apps/frontend/src/api/__tests__/client.test.ts
+++ b/apps/frontend/src/api/__tests__/client.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAuthStore } from '../../stores/useAuthStore';
-import type { AuthState } from '../../types/auth';
+import type { AuthState } from '../../types/Auth';
 import { apiClient } from '../client';
 
 // Mock the auth store's getState to control token presence

--- a/apps/frontend/src/api/endpoints/auth.ts
+++ b/apps/frontend/src/api/endpoints/auth.ts
@@ -1,4 +1,8 @@
-import type { LoginFormData, TokenResponse } from '../../types/auth';
+import type {
+  LoginFormData,
+  RegisterFormData,
+  TokenResponse,
+} from '../../types/Auth';
 import { apiClient } from '../client';
 
 // Login using OAuth2 form format to match backend
@@ -15,5 +19,19 @@ export async function login(form: LoginFormData): Promise<TokenResponse> {
       'Content-Type': 'application/x-www-form-urlencoded',
     },
     body: new URLSearchParams(entries),
+  });
+}
+
+// Register using JSON format to match backend
+export async function register(data: RegisterFormData): Promise<TokenResponse> {
+  // Transform RegisterFormData to match backend schema (exclude confirmPassword)
+  const { confirmPassword, ...registerData } = data;
+
+  return apiClient.request<TokenResponse>('/api/v1/auth/register', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(registerData),
   });
 }

--- a/apps/frontend/src/components/ui/Input.tsx
+++ b/apps/frontend/src/components/ui/Input.tsx
@@ -122,7 +122,11 @@ export function Input({
           className="mb-1 text-sm font-medium text-gray-700"
         >
           {label}
-          {required && <span className="ml-1 text-red-500">*</span>}
+          {required && (
+            <span className="ml-1 text-red-500" aria-hidden="true">
+              *
+            </span>
+          )}
         </label>
       )}
 

--- a/apps/frontend/src/pages/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { login } from '../api/endpoints/auth';
 import { Button } from '../components/ui/Button';
-import { Input } from '../components/ui/Input';
 import { Card } from '../components/ui/Card';
 import { Container } from '../components/ui/Container';
+import { Input } from '../components/ui/Input';
 import { useAuthStore } from '../stores/useAuthStore';
-import { login } from '../api/endpoints/auth';
-import type { LoginFormData } from '../types/auth';
+import type { LoginFormData } from '../types/Auth';
 
 const LoginPage: React.FC = () => {
   const [formData, setFormData] = useState<LoginFormData>({
@@ -104,6 +104,18 @@ const LoginPage: React.FC = () => {
               {isLoading ? 'Signing in...' : 'Sign In'}
             </Button>
           </form>
+
+          <div className="mt-6 text-center">
+            <p className="text-sm text-gray-600">
+              Need an account?{' '}
+              <Link
+                to="/register"
+                className="font-medium text-blue-600 transition-colors hover:text-blue-500"
+              >
+                Register
+              </Link>
+            </p>
+          </div>
         </Card>
       </div>
     </Container>

--- a/apps/frontend/src/pages/RegisterPage.tsx
+++ b/apps/frontend/src/pages/RegisterPage.tsx
@@ -1,0 +1,347 @@
+import React, { useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { register } from '../api/endpoints/auth';
+import { Button } from '../components/ui/Button';
+import { Card } from '../components/ui/Card';
+import { Container } from '../components/ui/Container';
+import { Input } from '../components/ui/Input';
+import { useAuthStore } from '../stores/useAuthStore';
+import type { RegisterFormData } from '../types/Auth';
+
+interface ValidationErrors {
+  username?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+  first_name?: string;
+  last_name?: string;
+}
+
+const RegisterPage: React.FC = () => {
+  const [formData, setFormData] = useState<RegisterFormData>({
+    username: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+    first_name: '',
+    last_name: '',
+  });
+  const [validationErrors, setValidationErrors] = useState<ValidationErrors>(
+    {}
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const navigate = useNavigate();
+  const location = useLocation();
+  const authStore = useAuthStore();
+
+  // Get the intended destination or default to home
+  const from = (location.state as { from?: string })?.from || '/';
+
+  // Validation functions
+  const validateUsername = (username: string): string | undefined => {
+    if (!username) return 'Username is required';
+    if (username.length < 3) return 'Username must be at least 3 characters';
+    if (username.length > 32)
+      return 'Username must be no more than 32 characters';
+    if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
+      return 'Username can only contain letters, numbers, underscores, and hyphens';
+    }
+    return undefined;
+  };
+
+  const validateEmail = (email: string): string | undefined => {
+    if (!email) return 'Email is required';
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) return 'Please enter a valid email address';
+    return undefined;
+  };
+
+  const validatePassword = (password: string): string | undefined => {
+    if (!password) return 'Password is required';
+    if (password.length < 12) return 'Password must be at least 12 characters';
+    return undefined;
+  };
+
+  const validateConfirmPassword = (
+    confirmPassword: string,
+    password: string
+  ): string | undefined => {
+    if (!confirmPassword) return 'Please confirm your password';
+    if (confirmPassword !== password) return 'Passwords do not match';
+    return undefined;
+  };
+
+  const validateFirstName = (firstName: string): string | undefined => {
+    if (firstName && firstName.length > 50)
+      return 'First name must be no more than 50 characters';
+    return undefined;
+  };
+
+  const validateLastName = (lastName: string): string | undefined => {
+    if (lastName && lastName.length > 50)
+      return 'Last name must be no more than 50 characters';
+    return undefined;
+  };
+
+  // Real-time validation
+  const validateField = (name: keyof RegisterFormData, value: string) => {
+    let fieldError: string | undefined;
+
+    switch (name) {
+      case 'username':
+        fieldError = validateUsername(value);
+        break;
+      case 'email':
+        fieldError = validateEmail(value);
+        break;
+      case 'password':
+        fieldError = validatePassword(value);
+        // Also revalidate confirm password if it exists
+        if (formData.confirmPassword) {
+          const confirmError = validateConfirmPassword(
+            formData.confirmPassword,
+            value
+          );
+          setValidationErrors((prev) => ({
+            ...prev,
+            confirmPassword: confirmError,
+          }));
+        }
+        break;
+      case 'confirmPassword':
+        fieldError = validateConfirmPassword(value, formData.password);
+        break;
+      case 'first_name':
+        fieldError = validateFirstName(value);
+        break;
+      case 'last_name':
+        fieldError = validateLastName(value);
+        break;
+    }
+
+    setValidationErrors((prev) => ({ ...prev, [name]: fieldError }));
+  };
+
+  // Check if form is valid
+  const isFormValid = () => {
+    const errors = {
+      username: validateUsername(formData.username),
+      email: validateEmail(formData.email),
+      password: validatePassword(formData.password),
+      confirmPassword: validateConfirmPassword(
+        formData.confirmPassword,
+        formData.password
+      ),
+      first_name: validateFirstName(formData.first_name || ''),
+      last_name: validateLastName(formData.last_name || ''),
+    };
+
+    return !Object.values(errors).some((error) => error !== undefined);
+  };
+
+  const handleInputChange =
+    (name: keyof RegisterFormData) => (value: string) => {
+      setFormData((prev) => ({ ...prev, [name]: value }));
+      // Clear general error when user starts typing
+      if (error) setError(null);
+      // Perform real-time validation
+      validateField(name, value);
+    };
+
+  const handleInputBlur = (name: keyof RegisterFormData) => () => {
+    // Validate field on blur for immediate feedback
+    validateField(name, formData[name] || '');
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    // Validate all fields before submission
+    const errors = {
+      username: validateUsername(formData.username),
+      email: validateEmail(formData.email),
+      password: validatePassword(formData.password),
+      confirmPassword: validateConfirmPassword(
+        formData.confirmPassword,
+        formData.password
+      ),
+      first_name: validateFirstName(formData.first_name || ''),
+      last_name: validateLastName(formData.last_name || ''),
+    };
+
+    setValidationErrors(errors);
+
+    // Check if there are any validation errors
+    if (Object.values(errors).some((error) => error !== undefined)) {
+      setError('Please fix the errors above before submitting');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await register(formData);
+      // Store token using auth store
+      authStore.setToken(response.access_token);
+      // Navigate to intended page or home
+      navigate(from, { replace: true });
+    } catch (err: any) {
+      const status = err?.status;
+      const message = String(err?.message || '');
+      const messageLower = message.toLowerCase();
+
+      if (status === 400 || status === 409) {
+        // Handle specific validation errors from backend (case-insensitive match)
+        if (
+          messageLower.includes('username') ||
+          (messageLower.includes('exist') && !messageLower.includes('email'))
+        ) {
+          setError('Username is already taken');
+        } else if (
+          messageLower.includes('email') ||
+          (messageLower.includes('exist') && messageLower.includes('email'))
+        ) {
+          setError('Email is already registered');
+        } else {
+          setError('Invalid registration data. Please check your inputs.');
+        }
+      } else if (status === 422) {
+        setError('Invalid registration data. Please check your inputs.');
+      } else {
+        setError(message || 'Registration failed. Please try again.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Container size="sm">
+      <div className="flex min-h-screen flex-col items-center justify-center">
+        <Card variant="default" className="w-full max-w-md p-6">
+          <h1 className="mb-6 text-center text-2xl font-bold">
+            Join PantryPilot
+          </h1>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              label="Username"
+              name="username"
+              type="text"
+              value={formData.username}
+              onChange={handleInputChange('username')}
+              onBlur={handleInputBlur('username')}
+              placeholder="Enter your username"
+              required
+              disabled={isLoading}
+              error={validationErrors.username}
+              helperText="3-32 characters, letters, numbers, underscores, and hyphens only"
+            />
+
+            <Input
+              label="Email"
+              name="email"
+              type="email"
+              value={formData.email}
+              onChange={handleInputChange('email')}
+              onBlur={handleInputBlur('email')}
+              placeholder="Enter your email address"
+              required
+              disabled={isLoading}
+              error={validationErrors.email}
+              autoComplete="email"
+            />
+
+            <Input
+              label="Password"
+              name="password"
+              type="password"
+              value={formData.password}
+              onChange={handleInputChange('password')}
+              onBlur={handleInputBlur('password')}
+              placeholder="Enter your password"
+              required
+              disabled={isLoading}
+              error={validationErrors.password}
+              helperText="Minimum 12 characters"
+              autoComplete="new-password"
+            />
+
+            <Input
+              label="Confirm Password"
+              name="confirmPassword"
+              type="password"
+              value={formData.confirmPassword}
+              onChange={handleInputChange('confirmPassword')}
+              onBlur={handleInputBlur('confirmPassword')}
+              placeholder="Confirm your password"
+              required
+              disabled={isLoading}
+              error={validationErrors.confirmPassword}
+              autoComplete="new-password"
+            />
+
+            <Input
+              label="First Name"
+              name="first_name"
+              type="text"
+              value={formData.first_name || ''}
+              onChange={handleInputChange('first_name')}
+              onBlur={handleInputBlur('first_name')}
+              placeholder="Enter your first name (optional)"
+              disabled={isLoading}
+              error={validationErrors.first_name}
+              autoComplete="given-name"
+            />
+
+            <Input
+              label="Last Name"
+              name="last_name"
+              type="text"
+              value={formData.last_name || ''}
+              onChange={handleInputChange('last_name')}
+              onBlur={handleInputBlur('last_name')}
+              placeholder="Enter your last name (optional)"
+              disabled={isLoading}
+              error={validationErrors.last_name}
+              autoComplete="family-name"
+            />
+
+            {error && (
+              <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+                {error}
+              </div>
+            )}
+
+            <Button
+              type="submit"
+              variant="primary"
+              className="w-full"
+              loading={isLoading}
+              disabled={isLoading || !isFormValid()}
+            >
+              {isLoading ? 'Creating Account...' : 'Create Account'}
+            </Button>
+          </form>
+
+          <div className="mt-6 text-center">
+            <p className="text-sm text-gray-600">
+              Already have an account?{' '}
+              <Link
+                to="/login"
+                className="font-medium text-blue-600 transition-colors hover:text-blue-500"
+              >
+                Login
+              </Link>
+            </p>
+          </div>
+        </Card>
+      </div>
+    </Container>
+  );
+};
+
+export default RegisterPage;

--- a/apps/frontend/src/pages/__tests__/RegisterPage.test.tsx
+++ b/apps/frontend/src/pages/__tests__/RegisterPage.test.tsx
@@ -1,0 +1,633 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import RegisterPage from '../RegisterPage';
+import { useAuthStore } from '../../stores/useAuthStore';
+import * as authApi from '../../api/endpoints/auth';
+import type { TokenResponse } from '../../types/Auth';
+
+// Mock the auth API
+vi.mock('../../api/endpoints/auth', () => ({
+  register: vi.fn(),
+}));
+
+// Mock the auth store
+vi.mock('../../stores/useAuthStore', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+// Mock react-router-dom navigation
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ state: null }),
+  };
+});
+
+describe('RegisterPage', () => {
+  const mockSetToken = vi.fn();
+  const mockAuthStore = {
+    token: null,
+    user: null,
+    hasHydrated: true,
+    login: vi.fn(),
+    logout: vi.fn(),
+    setToken: mockSetToken,
+    setUser: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useAuthStore as any).mockReturnValue(mockAuthStore);
+  });
+
+  const renderRegisterPage = (initialEntries = ['/register']) => {
+    return render(
+      <MemoryRouter initialEntries={initialEntries}>
+        <RegisterPage />
+      </MemoryRouter>
+    );
+  };
+
+  describe('Rendering Tests', () => {
+    it('renders correctly with all form fields', () => {
+      renderRegisterPage();
+
+      expect(
+        screen.getByRole('heading', { name: /join pantrypilot/i })
+      ).toBeDefined();
+      expect(screen.getByLabelText(/username/i)).toBeDefined();
+      expect(screen.getByLabelText(/email/i)).toBeDefined();
+      expect(
+        screen.getByLabelText(/^password\b/i, {
+          selector: 'input[name="password"]',
+        })
+      ).toBeDefined();
+      expect(screen.getByLabelText(/confirm password/i)).toBeDefined();
+      expect(screen.getByLabelText(/first name/i)).toBeDefined();
+      expect(screen.getByLabelText(/last name/i)).toBeDefined();
+    });
+
+    it('renders submit button initially disabled', () => {
+      renderRegisterPage();
+
+      const submitButton = screen.getByRole('button', {
+        name: /create account/i,
+      });
+      expect(submitButton.hasAttribute('disabled')).toBe(true);
+    });
+
+    it('displays form labels and helper text', () => {
+      renderRegisterPage();
+
+      expect(
+        screen.getByText(
+          '3-32 characters, letters, numbers, underscores, and hyphens only'
+        )
+      ).toBeDefined();
+      expect(screen.getByText('Minimum 12 characters')).toBeDefined();
+    });
+
+    it('renders login link', () => {
+      renderRegisterPage();
+
+      const loginLink = screen.getByRole('link', { name: /login/i });
+      expect(loginLink).toBeDefined();
+      expect(loginLink.getAttribute('href')).toBe('/login');
+    });
+  });
+
+  describe('Validation Tests', () => {
+    it('validates username - required', async () => {
+      const user = userEvent.setup();
+      renderRegisterPage();
+
+      const usernameInput = screen.getByLabelText(/username/i);
+      await user.click(usernameInput);
+      await user.tab(); // blur the field
+
+      await waitFor(() => {
+        expect(screen.getByText('Username is required')).toBeDefined();
+      });
+    });
+
+    it('validates username - minimum length', async () => {
+      const user = userEvent.setup();
+      renderRegisterPage();
+
+      const usernameInput = screen.getByLabelText(/username/i);
+      await user.type(usernameInput, 'ab');
+      await user.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Username must be at least 3 characters')
+        ).toBeDefined();
+      });
+    });
+
+    it('validates email - required', async () => {
+      const user = userEvent.setup();
+      renderRegisterPage();
+
+      const emailInput = screen.getByLabelText(/email/i);
+      await user.click(emailInput);
+      await user.tab();
+
+      await waitFor(() => {
+        expect(screen.getByText('Email is required')).toBeDefined();
+      });
+    });
+
+    it('validates email - format', async () => {
+      const user = userEvent.setup();
+      renderRegisterPage();
+
+      const emailInput = screen.getByLabelText(/email/i);
+      await user.type(emailInput, 'invalid-email');
+      await user.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Please enter a valid email address')
+        ).toBeDefined();
+      });
+    });
+
+    it('validates password - required', async () => {
+      const user = userEvent.setup();
+      renderRegisterPage();
+
+      const passwordInput = screen.getByLabelText(/^password\b/i, {
+        selector: 'input[name="password"]',
+      });
+      await user.click(passwordInput);
+      await user.tab();
+
+      await waitFor(() => {
+        expect(screen.getByText('Password is required')).toBeDefined();
+      });
+    });
+
+    it('validates password - minimum length', async () => {
+      const user = userEvent.setup();
+      renderRegisterPage();
+
+      const passwordInput = screen.getByLabelText(/^password\b/i, {
+        selector: 'input[name="password"]',
+      });
+      await user.type(passwordInput, 'short');
+      await user.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Password must be at least 12 characters')
+        ).toBeDefined();
+      });
+    });
+
+    it('validates confirm password - must match', async () => {
+      const user = userEvent.setup();
+      renderRegisterPage();
+
+      const passwordInput = screen.getByLabelText(/^password\b/i, {
+        selector: 'input[name="password"]',
+      });
+      const confirmPasswordInput = screen.getByLabelText(/confirm password/i);
+
+      await user.type(passwordInput, 'password123456');
+      await user.type(confirmPasswordInput, 'differentpassword');
+      await user.tab();
+
+      await waitFor(() => {
+        expect(screen.getByText('Passwords do not match')).toBeDefined();
+      });
+    });
+  });
+
+  describe('Form Interaction Tests', () => {
+    it('allows user to type in all form fields', async () => {
+      const user = userEvent.setup();
+      renderRegisterPage();
+
+      const usernameInput = screen.getByLabelText(
+        /username/i
+      ) as HTMLInputElement;
+      const emailInput = screen.getByLabelText(/email/i) as HTMLInputElement;
+      const passwordInput = screen.getByLabelText(/^password\b/i, {
+        selector: 'input[name="password"]',
+      }) as HTMLInputElement;
+      const confirmPasswordInput = screen.getByLabelText(
+        /confirm password/i
+      ) as HTMLInputElement;
+      const firstNameInput = screen.getByLabelText(
+        /first name/i
+      ) as HTMLInputElement;
+      const lastNameInput = screen.getByLabelText(
+        /last name/i
+      ) as HTMLInputElement;
+
+      await user.type(usernameInput, 'testuser');
+      await user.type(emailInput, 'test@example.com');
+      await user.type(passwordInput, 'password123456');
+      await user.type(confirmPasswordInput, 'password123456');
+      await user.type(firstNameInput, 'John');
+      await user.type(lastNameInput, 'Doe');
+
+      expect(usernameInput.value).toBe('testuser');
+      expect(emailInput.value).toBe('test@example.com');
+      expect(passwordInput.value).toBe('password123456');
+      expect(confirmPasswordInput.value).toBe('password123456');
+      expect(firstNameInput.value).toBe('John');
+      expect(lastNameInput.value).toBe('Doe');
+    });
+
+    it('enables submit button when all validation passes', async () => {
+      const user = userEvent.setup();
+      renderRegisterPage();
+
+      const submitButton = screen.getByRole('button', {
+        name: /create account/i,
+      });
+      expect(submitButton.hasAttribute('disabled')).toBe(true);
+
+      // Fill in valid form data
+      await user.type(screen.getByLabelText(/username/i), 'testuser');
+      await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+      await user.type(
+        screen.getByLabelText(/^password\b/i, {
+          selector: 'input[name="password"]',
+        }),
+        'password123456'
+      );
+      await user.type(
+        screen.getByLabelText(/confirm password/i),
+        'password123456'
+      );
+
+      await waitFor(() => {
+        expect(submitButton.hasAttribute('disabled')).toBe(false);
+      });
+    });
+  });
+
+  describe('API Integration Tests', () => {
+    it('calls register API with correct data on successful submission', async () => {
+      const user = userEvent.setup();
+      const mockRegister = vi.mocked(authApi.register);
+      mockRegister.mockResolvedValueOnce({
+        access_token: 'test-token',
+        token_type: 'bearer',
+      });
+
+      renderRegisterPage();
+
+      // Fill in valid form data
+      await user.type(screen.getByLabelText(/username/i), 'testuser');
+      await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+      await user.type(
+        screen.getByLabelText(/^password\b/i, {
+          selector: 'input[name="password"]',
+        }),
+        'password123456'
+      );
+      await user.type(
+        screen.getByLabelText(/confirm password/i),
+        'password123456'
+      );
+      await user.type(screen.getByLabelText(/first name/i), 'John');
+      await user.type(screen.getByLabelText(/last name/i), 'Doe');
+
+      const submitButton = screen.getByRole('button', {
+        name: /create account/i,
+      });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockRegister).toHaveBeenCalledWith({
+          username: 'testuser',
+          email: 'test@example.com',
+          password: 'password123456',
+          confirmPassword: 'password123456',
+          first_name: 'John',
+          last_name: 'Doe',
+        });
+      });
+    });
+
+    it('updates auth store and navigates on successful registration', async () => {
+      const user = userEvent.setup();
+      const mockRegister = vi.mocked(authApi.register);
+      mockRegister.mockResolvedValueOnce({
+        access_token: 'test-token',
+        token_type: 'bearer',
+      });
+
+      renderRegisterPage();
+
+      // Fill in valid form data
+      await user.type(screen.getByLabelText(/username/i), 'testuser');
+      await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+      await user.type(
+        screen.getByLabelText(/^password\b/i, {
+          selector: 'input[name="password"]',
+        }),
+        'password123456'
+      );
+      await user.type(
+        screen.getByLabelText(/confirm password/i),
+        'password123456'
+      );
+
+      const submitButton = screen.getByRole('button', {
+        name: /create account/i,
+      });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockSetToken).toHaveBeenCalledWith('test-token');
+        expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+      });
+    });
+
+    it('shows loading state during registration', async () => {
+      const user = userEvent.setup();
+      const mockRegister = vi.mocked(authApi.register);
+
+      // Create a promise that we can control
+      let resolveRegister: (value: TokenResponse) => void;
+      const registerPromise = new Promise<TokenResponse>((resolve) => {
+        resolveRegister = resolve;
+      });
+      mockRegister.mockReturnValueOnce(registerPromise);
+
+      renderRegisterPage();
+
+      // Fill in valid form data
+      await user.type(screen.getByLabelText(/username/i), 'testuser');
+      await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+      await user.type(
+        screen.getByLabelText(/^password\b/i, {
+          selector: 'input[name="password"]',
+        }),
+        'password123456'
+      );
+      await user.type(
+        screen.getByLabelText(/confirm password/i),
+        'password123456'
+      );
+
+      const submitButton = screen.getByRole('button', {
+        name: /create account/i,
+      });
+      await user.click(submitButton);
+
+      // Should show loading state
+      expect(
+        screen.getByRole('button', { name: /creating account/i })
+      ).toBeDefined();
+      expect(
+        screen
+          .getByRole('button', { name: /creating account/i })
+          .hasAttribute('disabled')
+      ).toBe(true);
+
+      // Resolve the promise
+      resolveRegister!({
+        access_token: 'test-token',
+        token_type: 'bearer',
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /create account/i })
+        ).toBeDefined();
+      });
+    });
+
+    it('shows error message on registration failure', async () => {
+      const user = userEvent.setup();
+      const mockRegister = vi.mocked(authApi.register);
+      mockRegister.mockRejectedValueOnce({
+        status: 400,
+        message: 'Username already exists',
+      });
+
+      renderRegisterPage();
+
+      // Fill in valid form data
+      await user.type(screen.getByLabelText(/username/i), 'existinguser');
+      await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+      await user.type(
+        screen.getByLabelText(/^password\b/i, {
+          selector: 'input[name="password"]',
+        }),
+        'password123456'
+      );
+      await user.type(
+        screen.getByLabelText(/confirm password/i),
+        'password123456'
+      );
+
+      const submitButton = screen.getByRole('button', {
+        name: /create account/i,
+      });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Username is already taken')).toBeDefined();
+      });
+    });
+
+    it('prevents submission with validation errors', async () => {
+      const user = userEvent.setup();
+      const mockRegister = vi.mocked(authApi.register);
+
+      renderRegisterPage();
+
+      // Fill in invalid form data
+      await user.type(screen.getByLabelText(/username/i), 'ab'); // Too short
+      await user.type(screen.getByLabelText(/email/i), 'invalid-email'); // Invalid format
+
+      const submitButton = screen.getByRole('button', {
+        name: /create account/i,
+      });
+      await user.click(submitButton);
+
+      // The submit button remains disabled when form is invalid; no top-level submit error is shown.
+      expect(submitButton.hasAttribute('disabled')).toBe(true);
+
+      // Field-level validation messages should be present
+      expect(
+        screen.getByText('Username must be at least 3 characters')
+      ).toBeDefined();
+      expect(
+        screen.getByText('Please enter a valid email address')
+      ).toBeDefined();
+
+      // API should not be called
+      expect(mockRegister).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Accessibility Tests', () => {
+    it('has proper form labels', () => {
+      renderRegisterPage();
+
+      expect(screen.getByLabelText(/username/i)).toBeDefined();
+      expect(screen.getByLabelText(/email/i)).toBeDefined();
+      expect(
+        screen.getByLabelText(/^password\b/i, {
+          selector: 'input[name="password"]',
+        })
+      ).toBeDefined();
+      expect(screen.getByLabelText(/confirm password/i)).toBeDefined();
+      expect(screen.getByLabelText(/first name/i)).toBeDefined();
+      expect(screen.getByLabelText(/last name/i)).toBeDefined();
+    });
+
+    it('has proper form structure', () => {
+      renderRegisterPage();
+
+      // Check that the form element exists by tag name since it doesn't have role="form"
+      const form = document.querySelector('form');
+      expect(form).toBeDefined();
+    });
+
+    it('has proper button roles and states', () => {
+      renderRegisterPage();
+
+      const submitButton = screen.getByRole('button', {
+        name: /create account/i,
+      });
+      expect(submitButton.getAttribute('type')).toBe('submit');
+    });
+
+    it('has proper link accessibility', () => {
+      renderRegisterPage();
+
+      const loginLink = screen.getByRole('link', { name: /login/i });
+      expect(loginLink.getAttribute('href')).toBe('/login');
+    });
+  });
+});
+
+// Additional error handling coverage tests appended outside the main describe block
+// to increase RegisterPage.tsx coverage (target ≥95%).
+
+describe('RegisterPage - Additional Error Handling', () => {
+  const renderRegisterPage = (initialEntries = ['/register']) => {
+    return render(
+      <MemoryRouter initialEntries={initialEntries}>
+        <RegisterPage />
+      </MemoryRouter>
+    );
+  };
+
+  it('shows email taken message on 409 conflict', async () => {
+    const user = userEvent.setup();
+    const mockRegister = vi.mocked(authApi.register);
+    mockRegister.mockRejectedValueOnce({
+      status: 409,
+      message: 'Email already exists',
+    });
+
+    renderRegisterPage();
+
+    await user.type(screen.getByLabelText(/username/i), 'existinguser2');
+    await user.type(screen.getByLabelText(/email/i), 'dup@example.com');
+    await user.type(
+      screen.getByLabelText(/^password\b/i, {
+        selector: 'input[name="password"]',
+      }),
+      'password123456'
+    );
+    await user.type(
+      screen.getByLabelText(/confirm password/i),
+      'password123456'
+    );
+
+    const submitButton = screen.getByRole('button', {
+      name: /create account/i,
+    });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Email is already registered')).toBeDefined();
+    });
+  });
+
+  it('shows generic invalid data message on 422', async () => {
+    const user = userEvent.setup();
+    const mockRegister = vi.mocked(authApi.register);
+    mockRegister.mockRejectedValueOnce({
+      status: 422,
+      message: 'Invalid data',
+    });
+
+    renderRegisterPage();
+
+    await user.type(screen.getByLabelText(/username/i), 'baduser');
+    await user.type(screen.getByLabelText(/email/i), 'invalid@example.com');
+    await user.type(
+      screen.getByLabelText(/^password\b/i, {
+        selector: 'input[name="password"]',
+      }),
+      'password123456'
+    );
+    await user.type(
+      screen.getByLabelText(/confirm password/i),
+      'password123456'
+    );
+
+    const submitButton = screen.getByRole('button', {
+      name: /create account/i,
+    });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Invalid registration data. Please check your inputs.')
+      ).toBeDefined();
+    });
+  });
+
+  it('shows fallback generic message on unknown server error', async () => {
+    const user = userEvent.setup();
+    const mockRegister = vi.mocked(authApi.register);
+    mockRegister.mockRejectedValueOnce({
+      status: 500,
+      message: '',
+    });
+
+    renderRegisterPage();
+
+    await user.type(screen.getByLabelText(/username/i), 'servererruser');
+    await user.type(screen.getByLabelText(/email/i), 'server@err.com');
+    await user.type(
+      screen.getByLabelText(/^password\b/i, {
+        selector: 'input[name="password"]',
+      }),
+      'password123456'
+    );
+    await user.type(
+      screen.getByLabelText(/confirm password/i),
+      'password123456'
+    );
+
+    const submitButton = screen.getByRole('button', {
+      name: /create account/i,
+    });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Registration failed. Please try again.')
+      ).toBeDefined();
+    });
+  });
+});

--- a/apps/frontend/src/routerConfig.tsx
+++ b/apps/frontend/src/routerConfig.tsx
@@ -4,9 +4,13 @@ import HydrateFallback from './components/HydrateFallback';
 import ProtectedRoute from './components/ProtectedRoute';
 import Root from './components/Root';
 import { LoadingSpinner } from './components/ui/LoadingSpinner';
+import { useAuthStore } from './stores/useAuthStore';
+import { useMealPlanStore } from './stores/useMealPlanStore';
+import { useRecipeStore } from './stores/useRecipeStore';
 // Lazy loaded pages for code-splitting
 const HomePage = React.lazy(() => import('./pages/HomePage'));
 const LoginPage = React.lazy(() => import('./pages/LoginPage'));
+const RegisterPage = React.lazy(() => import('./pages/RegisterPage'));
 const MealPlanPage = React.lazy(() => import('./pages/MealPlanPage'));
 const RecipesDetail = React.lazy(() => import('./pages/RecipesDetail'));
 const RecipesEditPage = React.lazy(() => import('./pages/RecipesEditPage'));
@@ -15,9 +19,6 @@ const RecipesPage = React.lazy(() => import('./pages/RecipesPage'));
 const ComponentShowcase = React.lazy(
   () => import('./pages/dev/ComponentShowcase')
 );
-import { useAuthStore } from './stores/useAuthStore';
-import { useMealPlanStore } from './stores/useMealPlanStore';
-import { useRecipeStore } from './stores/useRecipeStore';
 
 // Loader functions with auth checks
 const homeLoader = async () => {
@@ -111,6 +112,14 @@ export const router = createBrowserRouter([
         element: (
           <Suspense fallback={<LoadingSpinner />}>
             <LoginPage />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'register',
+        element: (
+          <Suspense fallback={<LoadingSpinner />}>
+            <RegisterPage />
           </Suspense>
         ),
       },

--- a/apps/frontend/src/setupTests.ts
+++ b/apps/frontend/src/setupTests.ts
@@ -1,5 +1,16 @@
+import { webcrypto as nodeWebcrypto } from 'node:crypto';
 import { mockAnimationsApi } from 'jsdom-testing-mocks';
 import { vi } from 'vitest';
+
+// Polyfill Web Crypto for test runtime if missing (fixes crypto.getRandomValues error)
+if (
+  typeof globalThis.crypto === 'undefined' ||
+  typeof (globalThis as any).crypto?.getRandomValues !== 'function'
+) {
+  // Assign Node's Web Crypto to the global for tests
+
+  (globalThis as any).crypto = nodeWebcrypto as unknown as Crypto;
+}
 
 // Setup animation mock for Headless UI
 mockAnimationsApi();

--- a/apps/frontend/src/stores/useAuthStore.ts
+++ b/apps/frontend/src/stores/useAuthStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import type { AuthState } from '../types/auth';
+import type { AuthState } from '../types/Auth';
 
 export const useAuthStore = create<AuthState>()(
   persist(

--- a/apps/frontend/src/types/auth.ts
+++ b/apps/frontend/src/types/auth.ts
@@ -10,6 +10,15 @@ export interface LoginFormData {
   password: string;
 }
 
+export interface RegisterFormData {
+  username: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  first_name?: string;
+  last_name?: string;
+}
+
 // Optional: Decoded token claims (if needed for storing basic claims like 'sub')
 export interface DecodedToken {
   sub: string;

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -1,7 +1,20 @@
-import { mergeConfig, defineConfig } from 'vitest/config';
+import { webcrypto as nodeWebcrypto } from 'node:crypto';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import svgr from 'vite-plugin-svgr';
+
+// Provide Web Crypto globally before Vite/Vitest server bootstraps.
+// Vitest executes this config in Node, so setting it here ensures availability
+// during early Vite initialization where crypto.getRandomValues() is used.
+if (
+  typeof (globalThis as any).crypto === 'undefined' ||
+  typeof (globalThis as any).crypto?.getRandomValues !== 'function'
+) {
+  (globalThis as any).crypto = nodeWebcrypto as any;
+}
+
+// Dynamically import vitest config AFTER polyfill so Vite sees global crypto
+const { mergeConfig, defineConfig } = await import('vitest/config');
 
 // Ensure Vitest uses the same plugin pipeline (especially @vitejs/plugin-react)
 // as the main Vite config so JSX is transformed with the automatic runtime.

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -7,6 +7,9 @@ Response envelope: `ApiResponse<T>` with `success`, `data`, `message`, `error`.
 ## Endpoints (v1)
 
 - GET `/api/v1/health` — health check
+- Authentication
+  - POST `/api/v1/auth/login` — user login (OAuth2-compatible)
+  - POST `/api/v1/auth/register` — user registration
 - Recipes
   - GET `/api/v1/recipes` — list with filters & pagination
   - POST `/api/v1/recipes` — create
@@ -17,6 +20,55 @@ Response envelope: `ApiResponse<T>` with `success`, `data`, `message`, `error`.
   - GET `/api/v1/mealplans/weekly`
   - PUT `/api/v1/mealplans/weekly`
   - POST `/api/v1/meals` `/api/v1/meals/{id}` (see schema)
+
+## Authentication Endpoints
+
+### POST `/api/v1/auth/register`
+
+**Description**: User registration endpoint that creates a new user account
+
+**Request Body**: JSON with UserRegister schema fields
+```json
+{
+  "username": "string (3-32 chars, alphanumeric, underscore, hyphen)",
+  "email": "string (valid email address)",
+  "password": "string (minimum 12 characters)",
+  "first_name": "string (optional)",
+  "last_name": "string (optional)"
+}
+```
+
+**Response**: 201 Created
+```json
+{
+  "access_token": "string",
+  "token_type": "bearer"
+}
+```
+
+**Error Responses**:
+- `400 Bad Request`: Password too short (less than 12 characters)
+- `409 Conflict`: Username or email already exists
+- `422 Unprocessable Entity`: Validation errors (invalid email, username pattern, missing required fields)
+
+### POST `/api/v1/auth/login`
+
+**Description**: OAuth2-compatible token login, get an access token for future requests
+
+**Request Body**: Form data (OAuth2PasswordRequestForm)
+- `username`: The user's username
+- `password`: The user's password
+
+**Response**: 200 OK
+```json
+{
+  "access_token": "string",
+  "token_type": "bearer"
+}
+```
+
+**Error Responses**:
+- `401 Unauthorized`: Incorrect username or password
 
 ## Schemas
 


### PR DESCRIPTION
# PR: feat/registration -> main

Summary
-------
This PR implements the registration feature and supporting adjustments across backend and frontend test harnesses and configurations. Changes include:

- Backend
  - Auth endpoints: registration and login behavior refinements and typing fixes
  - Security: Argon2 verify exception handling tightened and logging added
  - Tests: parametrized registration tests; `payload_namespace` fixture to create SimpleNamespace payloads for unit tests that bypass Pydantic validation
  - mypy/ruff config adjustments and targeted `# type: ignore` / `# noqa` justifications
  - Minor DB dependency and model re-export clarifications

- Frontend
  - Vitest config: WebCrypto polyfill and test setup improvements
  - Auth-related client and page tests updated
  - `package.json` test scripts updated (coverage, type-check)

Files changed (high level)
-------------------------
See `.tmp/diff_summary.txt` for the complete list and per-file diffs in `.tmp/diff_*.txt`.

CI and tests
------------
- `make ci` completed locally
  - Backend:
    - Ruff linting: passed
    - mypy: Success (no issues)
    - Pytest: 68 passed, coverage report written to `htmlcov` (TOTAL 75%)
  - Frontend:
    - ESLint: passed
    - Vitest: 132 tests passed (all test files passed), some console warnings about React `act()` in a few component tests (informational)

Notes for reviewers
-------------------
- Unit tests that directly call route handler functions use `SimpleNamespace` payloads to exercise manual validation branches. The `payload_namespace` fixture centralizes those payloads.
- Several small `# type: ignore` and `# noqa` remain; each now has a short justification comment explaining the reason.
- The Argon2 exception handling change in `core/security.py` reduces broad excepts and logs unexpected errors.

Checklist before merge
----------------------
- [ ] Review auth flow changes in `apps/backend/src/api/v1/auth.py` and `core/security.py`
- [ ] Confirm frontend integration tests are correct for auth page flows
- [ ] Decide whether to migrate remaining unit `SimpleNamespace` usage to `payload_namespace` (I can do this)
- [ ] Optionally open a follow-up to address `act()` warnings in frontend tests (not failing but worth addressing)

How to test locally
-------------------
From repository root:

```bash
make ci       # runs lint, type-check, tests for both backend and frontend (local CI convenience)
bash scripts/generate-diffs.sh main  # re-generate per-file diffs used in this PR
```

Generated artifacts
-------------------
- `.tmp/diff_summary.txt` — list of changed files and diff file names
- `.tmp/diff_*.txt` — individual per-file diffs
- `htmlcov/` — backend coverage HTML report (from tests)

If you want, I can open the GitHub PR from this branch to `main` and populate the description with this `pr.md` content. Say "open PR" and I will create the PR and copy this summary into the description.

Per-file changes (concise)
-------------------------
Below are 1-line summaries for each changed file (see `.tmp/diff_*.txt` for full diffs):

- `.kilocode/*` - internal Kilocode/MCP metadata and rule docs updated (project-specific policy/content additions).
- `README.md` - small doc updates (notes and references adjusted for the feature branch).
- `apps/backend/mypy.ini` - tightened/clarified mypy config: set `mypy_path=./src`, added `explicit_package_bases`, improved `exclude` regex, and enabled strict flags to match `pyproject.toml`.
- `apps/backend/src/api/v1/auth.py` - added `register` endpoint, reused token creation, integrated `UserRegister` schema, and handled duplicate-user conflicts with 409 responses.
- `apps/backend/src/api/v1/recipes.py` - improved typing for ingredient helpers (`ingredients_data: list[IngredientIn]`) to satisfy mypy.
- `apps/backend/src/core/config.py` - added explanation comment and scoped `# type: ignore[call-arg]` justification for Settings initializer using `_env_file`.
- `apps/backend/src/core/security.py` - tightened password verify exception handling (Argon2-specific exceptions), added logging, and improved type hints for token creation functions.
- `apps/backend/src/dependencies/db.py` - made dotenv import lazy inside `_load_env_files()` and narrowed exception handling to avoid module-level side effects and mypy issues.
- `apps/backend/src/models/__init__.py` - added package-level docstring justifying explicit re-exports and `# noqa: F401` usage.
- `apps/backend/src/models/recipe_ingredients.py` - added comment justifying a long SQLAlchemy column on a single line and kept `# noqa: E501` for readability.
- `apps/backend/src/schemas/auth.py` - added `UserRegister` Pydantic model (username/email/password validation) and imported `EmailStr`.
- `apps/backend/tests/conftest.py` - added `payload_namespace` fixture (SimpleNamespace factory) to centralize unit-test payload creation that bypasses Pydantic validation.
- `apps/backend/tests/test_auth_register.py` - new/rewritten registration test suite: added parametrized cases, unit-level tests exercising manual branches, and integration-style AsyncClient tests against in-memory SQLite.
- `apps/frontend/eslint.config.js` - small ESLint config adjustments (kept in diff summary for reviewer visibility).
- `apps/frontend/package.json` - updated `test:coverage` to set NODE_OPTIONS for global WebCrypto (Vitest coverage in Node environments).
- `apps/frontend/src/api/__tests__/auth.test.ts` - added registration API unit tests (happy path and error cases) and updated imports/types for register flow.
- `apps/frontend/src/api/__tests__/client.test.ts` - small test updates to align with API client behavior (headers, error handling) — see diff for details.
- `apps/frontend/src/api/endpoints/auth.ts` - added `register` client wrapper (excludes confirmPassword, handles errors) and related type updates.
- `apps/frontend/src/components/ui/Input.tsx` - minor component adjustments to support register form UX/labels (see diff for small markup/props changes).
- `apps/frontend/src/pages/LoginPage.tsx` - small updates to integrate with revised auth flows and tests.
- `apps/frontend/src/pages/RegisterPage.tsx` - new registration page component with validation, form state, and integration with `register` API and `useAuthStore`.
- `apps/frontend/src/pages/__tests__/RegisterPage.test.tsx` - new UI/integration tests for `RegisterPage` covering validation, submission, and store interaction (mocked API/store).
- `apps/frontend/src/routerConfig.tsx` - router adjustments related to new register route and navigation flows.
- `apps/frontend/src/setupTests.ts` - test setup tweaks (polyfills, global mocks) to support new Vitest config and WebCrypto polyfill.
- `apps/frontend/src/stores/useAuthStore.ts` - small updates to auth store types/usage to accommodate new registration flow.
- `apps/frontend/src/types/auth.ts` - added/updated registration-related types (`RegisterFormData`, `TokenResponse`), and adjusted naming for exports used in tests.
- `apps/frontend/vitest.config.ts` - added WebCrypto polyfill initialization to make `crypto.getRandomValues()` available during Vitest/Vite initialization.
- `docs/API_DESIGN.md` - updated API design notes to document auth/register behavior and expected status codes (400/409/201) and token semantics.

If you'd like, I can expand any of the per-file summaries into a short code review note and propose small follow-ups (e.g., migrate remaining SimpleNamespace usages, address act() warnings in frontend tests). Mark which files to expand and I'll add a short review note per file.
Branch status
-------------

- Local branch `feat/registration` has been created/updated to match the current work and pushed to `origin/feat/registration`.
- The branch is set to track `origin/feat/registration` and is ready for a PR to `main`.
- closes #71 
