### PR TITLE
fix(cloud): pass Upstash Redis secrets as environment variables

### DIFF
--- a/infra/modules/containerapps.bicep
+++ b/infra/modules/containerapps.bicep
@@ -142,8 +142,7 @@ resource backendApp 'Microsoft.App/containerApps@2024-10-02-preview' = {
               keyVaultUrl: '${keyVaultUri}secrets/geminiApiKey'
               identity: 'system'
             }
-          ],
-          empty(upstashRedisRestUrl)
+          ], empty(upstashRedisRestUrl)
             ? []
             : [
                 {


### PR DESCRIPTION
- update dev and prod deployment workflows to set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN as environment variables
- update Bicep infra and containerapps module to use direct values for Upstash Redis secrets instead of Key Vault references
- resolves deployment failure due to missing Key Vault access for Upstash secrets

☁️ - Generated by Copilot