### PR TITLE
fix(cloud): specify alembic.ini path in workflow commands

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Run Alembic migrations
         working-directory: apps/backend
         run: |
-          uv run alembic upgrade head
+          uv run alembic -c src/alembic.ini upgrade head
         env:
           DATABASE_URL: ${{ env.DATABASE_URL }}
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Run Alembic migrations
         working-directory: apps/backend
         run: |
-          uv run alembic upgrade head
+          uv run alembic -c src/alembic.ini upgrade head
         env:
           DATABASE_URL: ${{ env.DATABASE_URL }}
 


### PR DESCRIPTION
The alembic.ini file is located in apps/backend/src/, not apps/backend/. Add -c src/alembic.ini flag to alembic commands to find the config.