### PR TITLE
fix(build): add environment-scoped OIDC to image build workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -32,6 +32,7 @@ jobs:
   determine-environment:
     name: Determine Environment
     runs-on: ubuntu-latest
+    permissions: {} # No permissions needed for this job
     outputs:
       environment: ${{ steps.env.outputs.environment }}
     steps:


### PR DESCRIPTION
- split job to determine environment and run build under `environment:`
- enable OIDC with environment-scoped credentials so the workflow can use env-scoped federated creds
- update metadata/tags and registry output usage to reference determined environment