### PR TITLE
docs(application): note CI check names for rulesets

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -176,7 +176,7 @@
         "filename": "README.md",
         "hashed_secret": "81815b0d479353a566eae4f8f8efdff43a48f2c0",
         "is_verified": false,
-        "line_number": 75
+        "line_number": 77
       }
     ],
     "apps/backend/src/alembic.ini": [
@@ -461,5 +461,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-14T19:28:34Z"
+  "generated_at": "2025-12-15T13:09:33Z"
 }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Helps families plan the weekly meals and grocery list
 
 PantryPilot collects code coverage in CI for both backend (pytest + coverage.py) and frontend (Vitest). Reports are uploaded to Codecov.
 
+Note: The exact CI check names shown in GitHub PRs may be used as required status checks in branch rulesets.
+
 - CI workflow: see `.github/workflows/ci.yml` for steps uploading `apps/backend/coverage.xml` and `apps/frontend/coverage/lcov.info`.
 - Project dashboard: <https://codecov.io/gh/bryanostdiek/pantrypilot>
 


### PR DESCRIPTION
Small documentation-only change to trigger CI runs and capture the exact required status check names for GitHub branch rulesets.

🧪 - Generated by Copilot