### PR TITLE
chore(infra): merge main into production (2026-01-04)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -434,21 +434,7 @@
         "filename": "infra/main.json",
         "hashed_secret": "df174a3f2faa31814e06540acda7af8825403fac",
         "is_verified": false,
-        "line_number": 639
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "infra/main.json",
-        "hashed_secret": "29eeb7323a95aa81d9a6dd510b3d891f29c1056d",
-        "is_verified": false,
-        "line_number": 1131
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "infra/main.json",
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_verified": false,
-        "line_number": 1135
+        "line_number": 687
       }
     ],
     "scripts/migrate-data-to-azure.sh": [
@@ -461,5 +447,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-15T13:09:33Z"
+  "generated_at": "2026-01-04T19:14:01Z"
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -207,6 +207,12 @@ var corsOrigins = concat(
       ]
 )
 
+// Email sender address for Azure Communication Services
+// Uses the fromSenderDomain from the communication module to construct the full address
+var emailSenderAddress = communication.outputs.?fromSenderDomain != null
+  ? 'DoNotReply@${communication.outputs.?fromSenderDomain}'
+  : ''
+
 module containerApps 'modules/containerapps.bicep' = {
   params: {
     environmentName: resourceNames.containerAppsEnv
@@ -222,8 +228,10 @@ module containerApps 'modules/containerapps.bicep' = {
     registryUsername: useQuickstartImage ? '' : acrResource.listCredentials().username
     registryPassword: useQuickstartImage ? '' : acrResource.listCredentials().passwords[0].value
     corsOrigins: corsOrigins
+    emailSenderAddress: emailSenderAddress
     tags: commonTags
   }
+  dependsOn: [acsConnectionStringSecret]  // Ensure ACS secret is in Key Vault before Container App tries to reference it
 }
 
 // Reference the Key Vault resource for scoping role assignment

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "6484707175493839749"
+      "templateHash": "8762506374355152917"
     }
   },
   "parameters": {
@@ -1222,6 +1222,7 @@
           "corsOrigins": {
             "value": "[concat(createArray(format('https://{0}', reference('staticWebApp').outputs.defaultHostname.value)), if(equals(parameters('environmentName'), 'prod'), if(variables('useFrontendCustomDomains'), variables('frontendCustomDomains'), createArray()), createArray('http://localhost:5173', 'http://127.0.0.1:5173')))]"
           },
+          "emailSenderAddress": "[if(not(equals(tryGet(tryGet(reference('communication').outputs, 'fromSenderDomain'), 'value'), null())), createObject('value', format('DoNotReply@{0}', tryGet(tryGet(reference('communication').outputs, 'fromSenderDomain'), 'value'))), createObject('value', ''))]",
           "tags": {
             "value": "[variables('commonTags')]"
           }
@@ -1233,7 +1234,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.39.26.7824",
-              "templateHash": "7670517266156934026"
+              "templateHash": "1207037062499577004"
             }
           },
           "parameters": {
@@ -1326,6 +1327,13 @@
               "metadata": {
                 "description": "Upstash Redis REST Token for rate limiting (optional)"
               }
+            },
+            "emailSenderAddress": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Email sender address for Azure Communication Services (e.g., DoNotReply@domain.com)"
+              }
             }
           },
           "resources": [
@@ -1404,7 +1412,7 @@
                     }
                   },
                   "registries": "[if(empty(parameters('registryServer')), createArray(), createArray(createObject('server', parameters('registryServer'), 'username', parameters('registryUsername'), 'passwordSecretRef', 'acr-password')))]",
-                  "secrets": "[concat(if(empty(parameters('registryPassword')), createArray(), createArray(createObject('name', 'acr-password', 'value', parameters('registryPassword')))), concat(createArray(createObject('name', 'database-connection-string', 'keyVaultUrl', format('{0}secrets/dbConnectionString', parameters('keyVaultUri')), 'identity', 'system'), createObject('name', 'secret-key', 'keyVaultUrl', format('{0}secrets/secretKey', parameters('keyVaultUri')), 'identity', 'system'), createObject('name', 'gemini-api-key', 'keyVaultUrl', format('{0}secrets/geminiApiKey', parameters('keyVaultUri')), 'identity', 'system')), if(or(empty(parameters('upstashRedisRestUrl')), empty(parameters('upstashRedisRestToken'))), createArray(), createArray(createObject('name', 'upstash-redis-url', 'value', parameters('upstashRedisRestUrl')), createObject('name', 'upstash-redis-token', 'value', parameters('upstashRedisRestToken'))))))]"
+                  "secrets": "[concat(if(empty(parameters('registryPassword')), createArray(), createArray(createObject('name', 'acr-password', 'value', parameters('registryPassword')))), concat(createArray(createObject('name', 'database-connection-string', 'keyVaultUrl', format('{0}secrets/dbConnectionString', parameters('keyVaultUri')), 'identity', 'system'), createObject('name', 'secret-key', 'keyVaultUrl', format('{0}secrets/secretKey', parameters('keyVaultUri')), 'identity', 'system'), createObject('name', 'gemini-api-key', 'keyVaultUrl', format('{0}secrets/geminiApiKey', parameters('keyVaultUri')), 'identity', 'system'), createObject('name', 'acs-connection-string', 'keyVaultUrl', format('{0}secrets/acsConnectionString', parameters('keyVaultUri')), 'identity', 'system')), if(or(empty(parameters('upstashRedisRestUrl')), empty(parameters('upstashRedisRestToken'))), createArray(), createArray(createObject('name', 'upstash-redis-url', 'value', parameters('upstashRedisRestUrl')), createObject('name', 'upstash-redis-token', 'value', parameters('upstashRedisRestToken'))))))]"
                 },
                 "template": {
                   "containers": [
@@ -1415,7 +1423,7 @@
                         "cpu": "[json('0.5')]",
                         "memory": "1Gi"
                       },
-                      "env": "[concat(createArray(createObject('name', 'DATABASE_URL', 'secretRef', 'database-connection-string'), createObject('name', 'SECRET_KEY', 'secretRef', 'secret-key'), createObject('name', 'GEMINI_API_KEY', 'secretRef', 'gemini-api-key'), createObject('name', 'ENVIRONMENT', 'value', if(contains(parameters('environmentName'), 'prod'), 'production', 'development')), createObject('name', 'LOG_LEVEL', 'value', 'INFO'), createObject('name', 'API_V1_STR', 'value', '/api/v1'), createObject('name', 'PROJECT_NAME', 'value', 'PantryPilot'), createObject('name', 'VERSION', 'value', '0.1.0'), createObject('name', 'ALGORITHM', 'value', 'HS256'), createObject('name', 'ACCESS_TOKEN_EXPIRE_MINUTES', 'value', '30'), createObject('name', 'PORT', 'value', '8000'), createObject('name', 'PYTHONPATH', 'value', '/app/src'), createObject('name', 'CORS_ORIGINS', 'value', join(parameters('corsOrigins'), ','))), if(or(empty(parameters('upstashRedisRestUrl')), empty(parameters('upstashRedisRestToken'))), createArray(), createArray(createObject('name', 'UPSTASH_REDIS_REST_URL', 'secretRef', 'upstash-redis-url'), createObject('name', 'UPSTASH_REDIS_REST_TOKEN', 'secretRef', 'upstash-redis-token'))))]",
+                      "env": "[concat(createArray(createObject('name', 'DATABASE_URL', 'secretRef', 'database-connection-string'), createObject('name', 'SECRET_KEY', 'secretRef', 'secret-key'), createObject('name', 'GEMINI_API_KEY', 'secretRef', 'gemini-api-key'), createObject('name', 'ENVIRONMENT', 'value', if(contains(parameters('environmentName'), 'prod'), 'production', 'development')), createObject('name', 'LOG_LEVEL', 'value', 'INFO'), createObject('name', 'API_V1_STR', 'value', '/api/v1'), createObject('name', 'PROJECT_NAME', 'value', 'PantryPilot'), createObject('name', 'VERSION', 'value', '0.1.0'), createObject('name', 'ALGORITHM', 'value', 'HS256'), createObject('name', 'ACCESS_TOKEN_EXPIRE_MINUTES', 'value', '30'), createObject('name', 'PORT', 'value', '8000'), createObject('name', 'PYTHONPATH', 'value', '/app/src'), createObject('name', 'CORS_ORIGINS', 'value', join(parameters('corsOrigins'), ',')), createObject('name', 'AZURE_COMMUNICATION_CONNECTION_STRING', 'secretRef', 'acs-connection-string'), createObject('name', 'EMAIL_SENDER_ADDRESS', 'value', parameters('emailSenderAddress'))), if(or(empty(parameters('upstashRedisRestUrl')), empty(parameters('upstashRedisRestToken'))), createArray(), createArray(createObject('name', 'UPSTASH_REDIS_REST_URL', 'secretRef', 'upstash-redis-url'), createObject('name', 'UPSTASH_REDIS_REST_TOKEN', 'secretRef', 'upstash-redis-token'))))]",
                       "probes": [
                         {
                           "type": "Liveness",
@@ -1506,6 +1514,8 @@
       },
       "dependsOn": [
         "acr",
+        "acsConnectionStringSecret",
+        "communication",
         "keyVault",
         "staticWebApp"
       ]

--- a/infra/modules/containerapps.bicep
+++ b/infra/modules/containerapps.bicep
@@ -42,6 +42,9 @@ param upstashRedisRestUrl string = ''
 @secure()
 param upstashRedisRestToken string = ''
 
+@description('Email sender address for Azure Communication Services (e.g., DoNotReply@domain.com)')
+param emailSenderAddress string = ''
+
 // Log Analytics Workspace for Container Apps
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: '${environmentName}-logs'
@@ -142,6 +145,11 @@ resource backendApp 'Microsoft.App/containerApps@2024-10-02-preview' = {
               keyVaultUrl: '${keyVaultUri}secrets/geminiApiKey'
               identity: 'system'
             }
+            {
+              name: 'acs-connection-string'
+              keyVaultUrl: '${keyVaultUri}secrets/acsConnectionString'
+              identity: 'system'
+            }
           ],
           empty(upstashRedisRestUrl) || empty(upstashRedisRestToken)
             ? []
@@ -220,6 +228,14 @@ resource backendApp 'Microsoft.App/containerApps@2024-10-02-preview' = {
               {
                 name: 'CORS_ORIGINS'
                 value: join(corsOrigins, ',')
+              }
+              {
+                name: 'AZURE_COMMUNICATION_CONNECTION_STRING'
+                secretRef: 'acs-connection-string' // pragma: allowlist secret
+              }
+              {
+                name: 'EMAIL_SENDER_ADDRESS'
+                value: emailSenderAddress
               }
             ],
             empty(upstashRedisRestUrl) || empty(upstashRedisRestToken)


### PR DESCRIPTION
## Summary

Merge `main` into `production` to bring production up to date with latest changes.

## Changes Included

- **fix(infra): add ACS connection string and email sender to Container App** (#218)
  - Wire up Azure Communication Services for transactional email
  - Add `AZURE_COMMUNICATION_CONNECTION_STRING` and `EMAIL_SENDER_ADDRESS` environment variables
  - Fixes email sending being disabled in production

## Conflict Resolution

Resolved merge conflict in `infra/main.bicep` by accepting main's `emailSenderAddress` variable configuration.

## Next Steps

After merging this PR, we'll create a reverse PR to merge `production` back to `main` to ensure both branches are in sync.