### PR TITLE
feat: Add FRONTEND_URL to Container Apps infrastructure for production email links

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -207,6 +207,12 @@ var corsOrigins = concat(
       ]
 )
 
+// Frontend URL for email links (verification, password reset)
+// Use custom domain for production, Static Web App default hostname otherwise
+var frontendUrl = environmentName == 'prod' && useFrontendCustomDomains
+  ? 'https://smartmealplanner.app'
+  : 'https://${staticWebApp.outputs.defaultHostname}'
+
 // Email sender address for Azure Communication Services
 // Uses the fromSenderDomain from the communication module to construct the full address
 var emailSenderAddress = communication.outputs.?fromSenderDomain != null
@@ -229,6 +235,7 @@ module containerApps 'modules/containerapps.bicep' = {
     registryPassword: useQuickstartImage ? '' : acrResource.listCredentials().passwords[0].value
     corsOrigins: corsOrigins
     emailSenderAddress: emailSenderAddress
+    frontendUrl: frontendUrl
     tags: commonTags
   }
   dependsOn: [acsConnectionStringSecret]  // Ensure ACS secret is in Key Vault before Container App tries to reference it

--- a/infra/modules/containerapps.bicep
+++ b/infra/modules/containerapps.bicep
@@ -45,6 +45,9 @@ param upstashRedisRestToken string = ''
 @description('Email sender address for Azure Communication Services (e.g., DoNotReply@domain.com)')
 param emailSenderAddress string = ''
 
+@description('Frontend URL for email links (password reset, verification). Include https:// protocol.')
+param frontendUrl string = ''
+
 // Log Analytics Workspace for Container Apps
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: '${environmentName}-logs'
@@ -236,6 +239,10 @@ resource backendApp 'Microsoft.App/containerApps@2024-10-02-preview' = {
               {
                 name: 'EMAIL_SENDER_ADDRESS'
                 value: emailSenderAddress
+              }
+              {
+                name: 'FRONTEND_URL'
+                value: frontendUrl
               }
             ],
             empty(upstashRedisRestUrl) || empty(upstashRedisRestToken)


### PR DESCRIPTION
## Summary

Add `FRONTEND_URL` environment variable to Azure Container Apps infrastructure to fix production email links.

## Problem

Email verification and password reset links in production were pointing to `http://localhost:5173` instead of the actual production frontend URL (`https://smartmealplanner.app`). This occurred because the backend's `FRONTEND_URL` environment variable was not set in the Container Apps deployment, causing it to fall back to the default value.

## Solution

1. Add `frontendUrl` parameter to `containerapps.bicep` module
2. Add `FRONTEND_URL` environment variable to Container Apps configuration
3. Construct `frontendUrl` variable in `main.bicep` with conditional logic:
   - Production with custom domains: `https://smartmealplanner.app`
   - Other environments: Static Web App default hostname with `https://`
4. Pass `frontendUrl` to containerApps module

## Changes

- **infra/modules/containerapps.bicep**:
  - Added `frontendUrl` parameter (line 45)
  - Added `FRONTEND_URL` environment variable to env array (lines 244-246)

- **infra/main.bicep**:
  - Added `frontendUrl` variable with environment-specific logic (lines 219-222)
  - Passed `frontendUrl` to containerApps module (line 232)

## Testing

- All Bicep templates validated without syntax errors
- Backend email configuration verified:
  - `config.py` reads `FRONTEND_URL` from environment variable
  - `email.py` uses `settings.FRONTEND_URL` for verification links (line 105)
  - `email.py` uses `settings.FRONTEND_URL` for password reset links (line 153)
- No backend code changes required

## Impact

- Email verification links will use production URL after deployment
- Password reset links will use production URL after deployment
- Supports both custom domain and default Static Web App hostname
- Infrastructure-only change; no breaking changes