### PR TITLE
 fix(infra): update production PostgreSQL storage to 128GB

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -49,7 +49,7 @@ var environmentSettings = {
     // Production-optimized settings
     acrSku: 'Standard'
     dbSku: 'Standard_B1ms'
-    dbStorageSize: 128  // Must be >= current size (128 GB). Azure PostgreSQL does not allow storage shrinking.
+    dbStorageSize: 128 // Must be >= current size (128 GB). Azure PostgreSQL does not allow storage shrinking.
     containerMinReplicas: 1
     containerMaxReplicas: 3
     containerCpu: '0.25'
@@ -201,9 +201,7 @@ var corsOrigins = concat(
   ],
   // Environment-specific additional origins
   environmentName == 'prod'
-    ? (useFrontendCustomDomains
-        ? frontendCustomDomains
-        : [])
+    ? (useFrontendCustomDomains ? frontendCustomDomains : [])
     : [
         // Development localhost origins (excluded from production)
         'http://localhost:5173'
@@ -244,7 +242,7 @@ module containerApps 'modules/containerapps.bicep' = {
     frontendUrl: frontendUrl
     tags: commonTags
   }
-  dependsOn: [acsConnectionStringSecret]  // Ensure ACS secret is in Key Vault before Container App tries to reference it
+  dependsOn: [acsConnectionStringSecret] // Ensure ACS secret is in Key Vault before Container App tries to reference it
 }
 
 // Reference the Key Vault resource for scoping role assignment

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "16702743433789414697"
+      "templateHash": "12566531019241437087"
     }
   },
   "parameters": {
@@ -91,7 +91,7 @@
       "prod": {
         "acrSku": "Standard",
         "dbSku": "Standard_B1ms",
-        "dbStorageSize": 64,
+        "dbStorageSize": 128,
         "containerMinReplicas": 1,
         "containerMaxReplicas": 3,
         "containerCpu": "0.25",


### PR DESCRIPTION
Azure PostgreSQL Flexible Server does not allow storage size reduction. The production database currently has 128GB storage, so the Bicep configuration must match or exceed this value to avoid deployment failures.

Updated dbStorageSize from 64GB to 128GB in production environment settings.

Fixes deployment error: "Requested data Disk size '65536' cannot be less than current size '131072'"