### PR TITLE
chore: sync main with production after v2.0.0 release

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -6968,6 +6968,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",


### PR DESCRIPTION
## Summary
Syncs main with production after the v2.0.0 release deployment.

## Changes
This PR merges the production branch into main to synchronize the branch histories.

**Actual file change:** 1 line in `package-lock.json` (adds `peer: true` to postcss entry)

## Why
- Aligns branch histories so future main→production deployments are cleaner
- Prevents confusing diffs when creating deployment PRs