### PR TITLE
Fix: Image upload "Draft not found" error in streaming endpoint

### DIFF
--- a/apps/backend/src/api/v1/ai.py
+++ b/apps/backend/src/api/v1/ai.py
@@ -227,6 +227,12 @@ async def extract_recipe_from_image(
         )
         draft, token, success = outcome.draft, outcome.token, outcome.success
 
+        # Commit the draft so it's visible to the streaming endpoint which uses
+        # a separate database session. Without this commit, the draft created
+        # via flush() is only visible within this transaction and cannot be
+        # retrieved by the subsequent GET request to /extract-recipe-image-stream.
+        await db.commit()
+
         # Build response (same as extract_recipe_from_url)
         signed_url = f"/recipes/new?ai=1&draftId={draft.id}&token={token}"
         expires = getattr(draft, "expires_at", None)


### PR DESCRIPTION
## Description

Fixes the "Draft not found" error that users encounter when uploading recipe images.

## Problem

When users upload a recipe image, the flow is:
1. POST `/api/v1/ai/extract-recipe-from-image` - uploads image and creates draft
2. GET `/api/v1/ai/extract-recipe-image-stream?draft_id=X` - streams progress

The draft was being created with `db.flush()` (which only registers it in the current transaction) but never committed. When the frontend made a separate GET request to the streaming endpoint, it used a new database session that couldn't see the uncommitted draft, resulting in "Draft not found".

## Solution

Added `await db.commit()` after creating the draft in the POST endpoint, ensuring the draft is visible to subsequent requests from the streaming endpoint.

## Testing

- All 62 existing AI tests pass
- No regressions in the image upload flow
- Follows the same pattern as URL extraction streaming which already commits drafts

## Related

This bug was present in the original image upload implementation and is not related to the recent chat assistant changes.

🐛