### PR TITLE
fix(bicep): add raiPolicyName and bump CognitiveServices API to 2025-09-01

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -188,7 +188,7 @@ module azureOpenAI 'modules/openai.bicep' = if (deployAzureOpenAI) {
 
 // Reference the Azure OpenAI account so we can read keys without exposing them as module outputs
 // Note: Use resourceNames.azureOpenAI directly instead of module output to avoid ARM reference() in existing resource name
-resource azureOpenAIAccount 'Microsoft.CognitiveServices/accounts@2025-06-01' existing = if (deployAzureOpenAI) {
+resource azureOpenAIAccount 'Microsoft.CognitiveServices/accounts@2025-09-01' existing = if (deployAzureOpenAI) {
   name: resourceNames.azureOpenAI
   dependsOn: [azureOpenAI]
 }

--- a/infra/modules/openai.bicep
+++ b/infra/modules/openai.bicep
@@ -21,7 +21,7 @@ param customSubDomainName string = name
 param deployments array = []
 
 // Azure OpenAI resource (Cognitive Services account with kind=OpenAI)
-resource openai 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
+resource openai 'Microsoft.CognitiveServices/accounts@2025-09-01' = {
   name: name
   location: location
   kind: 'OpenAI'
@@ -49,7 +49,7 @@ resource openai 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
 // Model deployments (e.g., gpt-4o-mini, gpt-4.1)
 // Use batchSize(1) to deploy sequentially - Azure OpenAI doesn't support parallel deployments
 @batchSize(1)
-resource modelDeployments 'Microsoft.CognitiveServices/accounts/deployments@2025-06-01' = [
+resource modelDeployments 'Microsoft.CognitiveServices/accounts/deployments@2025-09-01' = [
   for deployment in deployments: {
     parent: openai
     name: deployment.name
@@ -63,6 +63,7 @@ resource modelDeployments 'Microsoft.CognitiveServices/accounts/deployments@2025
         name: deployment.model
         version: deployment.?version ?? null
       }
+      raiPolicyName: deployment.?raiPolicyName ?? 'Microsoft.DefaultV2'
       versionUpgradeOption: deployment.?versionUpgradeOption ?? 'OnceNewDefaultVersionAvailable'
     }
   }


### PR DESCRIPTION
## Problem

Deployment `pantrypilot-dev-228` (and `-227`) failed with opaque Azure error `715-123420` in the `azureOpenAI` nested Bicep module. All 4 model deployments (gpt-4.1, gpt-5-mini, gpt-5-nano, text-embedding-3-small) already exist in Azure and show **Succeeded** status with the `DefaultV2` content filter applied.

## Root Cause

When ARM re-PUTs existing model deployments, the Bicep template must include the `raiPolicyName` property matching the content filter already assigned in Azure. Without it, ARM detects a conflict between the desired state (no RAI policy) and the actual state (`DefaultV2`), producing error `715-123420`.

PR #374 bumped the API version from `2024-10-01` → `2025-06-01` but did not address the missing `raiPolicyName`, so deployments continued to fail.

## Changes

### `infra/modules/openai.bicep`
- Bumped `Microsoft.CognitiveServices` API version from `2025-06-01` → `2025-09-01` (latest stable)
- Added `raiPolicyName: deployment.?raiPolicyName ?? 'Microsoft.DefaultV2'` to deployment properties — defaults to `Microsoft.DefaultV2` (matching existing Azure state) but allows per-deployment override via parameters

### `infra/main.bicep`
- Bumped the `existing` account reference from `2025-06-01` → `2025-09-01` to stay consistent

## Testing

- Merge and let CI trigger `pantrypilot-dev-229` deployment
- Expected: azureOpenAI module succeeds without `715-123420` error