### PR TITLE
fix(bicep): revert API to 2025-06-01, omit raiPolicyName to fix gpt-4.1 deployment

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -188,7 +188,7 @@ module azureOpenAI 'modules/openai.bicep' = if (deployAzureOpenAI) {
 
 // Reference the Azure OpenAI account so we can read keys without exposing them as module outputs
 // Note: Use resourceNames.azureOpenAI directly instead of module output to avoid ARM reference() in existing resource name
-resource azureOpenAIAccount 'Microsoft.CognitiveServices/accounts@2025-09-01' existing = if (deployAzureOpenAI) {
+resource azureOpenAIAccount 'Microsoft.CognitiveServices/accounts@2025-06-01' existing = if (deployAzureOpenAI) {
   name: resourceNames.azureOpenAI
   dependsOn: [azureOpenAI]
 }

--- a/infra/modules/openai.bicep
+++ b/infra/modules/openai.bicep
@@ -21,7 +21,7 @@ param customSubDomainName string = name
 param deployments array = []
 
 // Azure OpenAI resource (Cognitive Services account with kind=OpenAI)
-resource openai 'Microsoft.CognitiveServices/accounts@2025-09-01' = {
+resource openai 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
   name: name
   location: location
   kind: 'OpenAI'
@@ -49,7 +49,7 @@ resource openai 'Microsoft.CognitiveServices/accounts@2025-09-01' = {
 // Model deployments (e.g., gpt-4o-mini, gpt-4.1)
 // Use batchSize(1) to deploy sequentially - Azure OpenAI doesn't support parallel deployments
 @batchSize(1)
-resource modelDeployments 'Microsoft.CognitiveServices/accounts/deployments@2025-09-01' = [
+resource modelDeployments 'Microsoft.CognitiveServices/accounts/deployments@2025-06-01' = [
   for deployment in deployments: {
     parent: openai
     name: deployment.name
@@ -61,9 +61,11 @@ resource modelDeployments 'Microsoft.CognitiveServices/accounts/deployments@2025
       model: {
         format: 'OpenAI'
         name: deployment.model
-        version: deployment.?version ?? null
+        version: deployment.?version
       }
-      raiPolicyName: deployment.?raiPolicyName ?? 'Microsoft.DefaultV2'
+      // Only include raiPolicyName when explicitly specified in deployment config.
+      // Omitting it (null) preserves whatever content filter Azure already has assigned.
+      raiPolicyName: deployment.?raiPolicyName
       versionUpgradeOption: deployment.?versionUpgradeOption ?? 'OnceNewDefaultVersionAvailable'
     }
   }


### PR DESCRIPTION
## Problem

Deployments 227–229 all failed with `715-123420` on the `azureOpenAI` nested module.

## Investigation & Findings

Used Azure CLI to drill into deployment operations:

1. **The failing resource is specifically `ppoaidevdev001/gpt-4.1`** — confirmed via `az deployment operation group list`. The other 3 models (gpt-5-mini, gpt-5-nano, text-embedding-3-small) never even attempt because `@batchSize(1)` halts at the first failure.

2. **The same infra code that succeeded on Feb 20 failed on Feb 25** — zero code changes to `infra/` between those runs. This points to a **transient Azure CognitiveServices RP issue**, not a template bug.

3. **Direct CLI and REST API PUTs succeed right now:**
   - `az cognitiveservices account deployment create` → Succeeded
   - `az rest --method PUT` with API version `2025-09-01` + `raiPolicyName: Microsoft.DefaultV2` → Succeeded

4. **PR #375 introduced a `raiPolicyName` mismatch:** Azure had `raiPolicyName: null` on the gpt-4.1 deployment, but the Bicep was hardcoding `'Microsoft.DefaultV2'`. While a REST PUT with the same value succeeded, the hardcoded default was an unnecessary mutation on every deployment.

5. **Quota is fine:** gpt-4.1 Standard uses 10/50K tokens — well within limits.

## Changes

### `infra/modules/openai.bicep`
- **Reverted API** from `2025-09-01` → `2025-06-01` (the stable version used by official Azure Verified Modules)
- **Changed `raiPolicyName`** from hardcoded `'Microsoft.DefaultV2'` to `deployment.?raiPolicyName` (null/omitted). Bicep null properties are excluded from compiled ARM JSON, so ARM preserves whatever content filter Azure already has assigned.
- **Cleaned up `version`** to `deployment.?version` (same null-omission pattern, removes redundant `?? null`)

### `infra/main.bicep`
- Reverted `existing` account reference from `2025-09-01` → `2025-06-01` to stay consistent

## Risk Assessment

The underlying `715-123420` error appears transient (identical code worked 5 days earlier, and direct API calls work now). This PR removes two potential irritants (API bump, raiPolicyName mutation) so the deployment has the cleanest possible template. If the transient issue has resolved, deployment 230 should succeed.