### PR TITLE
fix(bicep): disable Azure OpenAI Bicep deployment in dev

### DIFF
--- a/infra/parameters/main.dev.bicepparam
+++ b/infra/parameters/main.dev.bicepparam
@@ -17,9 +17,10 @@ param braveSearchApiKey = readEnvironmentVariable('BRAVE_SEARCH_API_KEY', '')
 // Gemini API key for AI model access (used for chat/endpoints instead of Azure OpenAI)
 param geminiApiKey = readEnvironmentVariable('GEMINI_API_KEY', '')
 
-// Azure OpenAI - deploy models for other project parts, but use Gemini for chat/endpoints
-// Bicep is idempotent - if resources exist with matching config, deployment will pass
-param deployAzureOpenAI = true
+// Azure OpenAI - disabled in Bicep to avoid transient 715-123420 ARM failures.
+// Models (gpt-4.1, gpt-5-mini, gpt-5-nano, text-embedding-3-small) remain deployed
+// in Azure and can be managed manually for training/evaluation use cases.
+param deployAzureOpenAI = false
 param useAzureOpenAIForLLM = false
 param azureOpenAILocation = readEnvironmentVariable('AZURE_OPENAI_LOCATION', 'eastus2')
 param azureOpenAIApiKey = readEnvironmentVariable('AZURE_OPENAI_API_KEY', '')


### PR DESCRIPTION
## Problem

Deployments 227–230 all fail with `715-123420` on the `azureOpenAI` nested Bicep module (specifically `gpt-4.1`). Direct CLI and REST API calls succeed, pointing to a transient or auth-specific ARM issue that we can't resolve from the template side.

## Solution

Set `deployAzureOpenAI = false` in the dev parameters. Azure OpenAI is not used as the LLM provider (`useAzureOpenAIForLLM = false` already), so the models are only needed for manual training/evaluation (LLM-as-a-judge).

**Existing model deployments in Azure are unaffected** — Bicep simply stops managing them. They can be managed via the Azure Portal or CLI when needed.

## Changes

- `infra/parameters/main.dev.bicepparam`: `deployAzureOpenAI = true` → `false`