### PR TITLE
ops(bicep): optimize Azure costs - downgrade prod ACR, migrate to 32GB DB

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -104,6 +104,13 @@ jobs:
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             VCS_REF=${{ github.sha }}
 
+      - name: Purge old ACR images
+        run: |
+          az acr run \
+            --cmd "acr purge --filter '${{ env.IMAGE_NAME }}:.*' --ago 7d --untagged --keep 5" \
+            --registry ${{ secrets.ACR_NAME }} \
+            /dev/null || echo "⚠️ ACR purge failed (non-blocking)"
+
       - name: Output image info
         run: |
           echo "## Container Image Built 🐳" >> $GITHUB_STEP_SUMMARY

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -10,6 +10,9 @@ param location string = resourceGroup().location
 @description('Unique suffix for resource naming')
 param uniqueSuffix string = substring(uniqueString(resourceGroup().id), 0, 6)
 
+@description('Database name suffix (e.g., empty string for dev, "v2-" for prod after storage migration)')
+param dbNameSuffix string = ''
+
 @description('Database admin username')
 param dbAdminUsername string = 'pantrypilot_admin'
 
@@ -92,10 +95,10 @@ var environmentSettings = {
     keyVaultSku: 'standard'
   }
   prod: {
-    // Production-optimized settings
-    acrSku: 'Standard'
+    // Production-optimized settings (cost-optimized for low-traffic personal app)
+    acrSku: 'Basic'
     dbSku: 'Standard_B1ms'
-    dbStorageSize: 128 // Must be >= current size (128 GB). Azure PostgreSQL does not allow storage shrinking.
+    dbStorageSize: 32
     containerMinReplicas: 1
     containerMaxReplicas: 3
     containerCpu: '0.25'
@@ -113,7 +116,7 @@ var currentSettings = environmentSettings[environmentName]
 var resourceNames = {
   acr: 'pantrypilotacr${environmentName}${uniqueSuffix}'
   keyVault: 'ppkv${environmentName}${uniqueSuffix}'
-  postgreSQL: 'pantrypilot-db-${environmentName}-${uniqueSuffix}'
+  postgreSQL: 'pantrypilot-db-${environmentName}-${dbNameSuffix}${uniqueSuffix}'
   containerAppsEnv: 'pantrypilot-env-${environmentName}-${uniqueSuffix}'
   containerAppBackend: 'pantrypilot-backend-${environmentName}'
   staticWebApp: 'pantrypilot-frontend-${environmentName}-${uniqueSuffix}'

--- a/infra/parameters/main.prod.bicepparam
+++ b/infra/parameters/main.prod.bicepparam
@@ -3,6 +3,7 @@ using '../main.bicep'
 param environmentName = 'prod'
 param location = readEnvironmentVariable('AZURE_LOCATION', 'Central US')
 param uniqueSuffix = readEnvironmentVariable('AZURE_UNIQUE_SUFFIX', 'prod001')
+param dbNameSuffix = 'v2-'
 param dbAdminUsername = 'pantrypilot_admin'
 param dbAdminPassword = readEnvironmentVariable('DB_ADMIN_PASSWORD')
 param secretKey = readEnvironmentVariable('SECRET_KEY')


### PR DESCRIPTION
## Azure Cost Optimization

### Changes
- **Prod ACR Standard → Basic**: 1.6 GB used of 10 GB limit, saves ~$12/mo
- **Prod DB 128 GB → 32 GB**: Only 8.9 GB actual data (2.4 MB dump). New server `pantrypilot-db-prod-v2-prod001` already created and data restored
- **Automated ACR image purge**: Added to `build-images.yml` — keeps 5 most recent tags, purges images older than 7 days after each build
- **Bicep `dbNameSuffix` param**: Supports the `v2-` naming for the migrated prod DB

### Already applied via CLI
- Prod ACR downgraded to Basic ✅
- Old 128 GB prod DB deleted, new 32 GB server created ✅
- Data dumped and restored ✅
- Key Vault connection string updated ✅
- Backend health check passing ✅
- Old AzureML training images purged from dev ACR ✅

### Estimated Recurring Savings
| Action | Monthly Savings |
|---|---:|
| ACR Standard → Basic | ~$12 |
| DB 128 GB → 32 GB storage | ~$13 |
| ACR auto-purge (reduced overage) | ~$2-3 |
| **Total** | **~$27-28/mo** |

Reduces recurring monthly cost from ~$78 to ~$50 (~35% reduction).