### PR TITLE
fix(bicep): use environment tag for backend image

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -205,10 +205,11 @@ var useAzureOpenAI = useAzureOpenAIForLLM || (!empty(azureOpenAIEndpoint) && !em
 var resolvedAzureOpenAIEndpoint = deployAzureOpenAI ? azureOpenAI!.outputs.endpoint : azureOpenAIEndpoint
 
 // Container Apps Environment and Backend App
-// Use quickstart placeholder for initial deployment, or ACR image after CI/CD builds
+// Use quickstart placeholder for initial deployment, or the environment-specific ACR tag after CI/CD builds
+var backendImageTag = environmentName
 var containerImage = useQuickstartImage
   ? 'mcr.microsoft.com/k8se/quickstart:latest'
-  : '${acr.outputs.loginServer}/pantrypilot-backend:latest'
+  : '${acr.outputs.loginServer}/pantrypilot-backend:${backendImageTag}'
 
 // Reference existing ACR to get admin credentials (only needed when using ACR image)
 resource acrResource 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {


### PR DESCRIPTION
## Summary
Align the production Bicep deployment with the image tags the CI workflow actually publishes.

## Changes
- change the Container Apps image reference in `infra/main.bicep` from `latest` to the environment-specific tag
- keep initial quickstart behavior unchanged

## Why
Production image cleanup now removes older builds, and the production build workflow does not publish a persistent `latest` tag. Fresh infrastructure deployments were failing because Bicep still referenced `pantrypilot-backend:latest` while the deploy workflow updates the running app to `pantrypilot-backend:prod`.

## Validation
- `az bicep build --file infra/main.bicep`
- verified production ACR has `prod` tags but no `latest` tag
