### PR TITLE
fix(application): fix meal plan accept failures from chat assistant

### DIFF
--- a/apps/frontend/src/api/endpoints/mealPlans.ts
+++ b/apps/frontend/src/api/endpoints/mealPlans.ts
@@ -89,7 +89,7 @@ export async function createMealEntry(
   payload: MealEntryIn
 ): Promise<MealEntry> {
   const snake = toSnakeEntryIn(payload);
-  const resp = await apiClient.request<any>('/api/v1/meals', {
+  const resp = await apiClient.request<any>('/api/v1/meals/', {
     method: 'POST',
     body: JSON.stringify(snake),
   });

--- a/apps/frontend/src/pages/RecipesNewPage.tsx
+++ b/apps/frontend/src/pages/RecipesNewPage.tsx
@@ -482,12 +482,19 @@ const RecipesNewPage: FC = () => {
       // Use the store to add the recipe
       const result = await addRecipe(recipeData);
 
-      if (result) {
-        const createdRecipeId =
-          result && typeof result === 'object' && 'id' in result
-            ? ((result as { id?: string | null }).id ?? undefined)
-            : undefined;
+      // Re-read duplicateInfo from the store: set when addRecipe encounters a 409.
+      const currentDuplicateInfo = useRecipeStore.getState().duplicateInfo;
 
+      // Resolve the recipe ID: newly created, or an exact-duplicate's existing ID so
+      // the meal plan flow can still proceed without user friction.
+      const createdRecipeId: string | undefined =
+        result && typeof result === 'object' && 'id' in result
+          ? ((result as { id?: string | null }).id ?? undefined)
+          : (currentDuplicateInfo?.existing_recipe_id ?? undefined);
+
+      const isExistingDuplicate = !result && !!createdRecipeId;
+
+      if (result || isExistingDuplicate) {
         const proposalKey = searchParams.get('proposalKey');
         const chatConversationId =
           searchParams.get('chatConversationId') ?? undefined;
@@ -501,7 +508,9 @@ const RecipesNewPage: FC = () => {
           useChatStore
             .getState()
             .appendLocalAssistantMessage(
-              'Recipe saved to your recipe book. If you selected a meal plan day, I’ll add it next.',
+              isExistingDuplicate
+                ? 'This recipe is already in your recipe book. Adding it to your meal plan now.'
+                : 'Recipe saved to your recipe book. If you selected a meal plan day, I\u2019ll add it next.',
               chatConversationId
             );
         }
@@ -529,7 +538,9 @@ const RecipesNewPage: FC = () => {
                 );
             }
             success(
-              `Recipe created and added to meal plan for ${mealPlanDayLabel || mealPlanDate}!`
+              isExistingDuplicate
+                ? `Recipe already existed and was added to meal plan for ${mealPlanDayLabel || mealPlanDate}!`
+                : `Recipe created and added to meal plan for ${mealPlanDayLabel || mealPlanDate}!`
             );
 
             if (returnToAssistant && chatConversationId) {
@@ -538,13 +549,13 @@ const RecipesNewPage: FC = () => {
             }
           } catch (mealPlanErr) {
             logger.error('Failed to add recipe to meal plan:', mealPlanErr);
-            // Still show success for recipe creation, but warn about meal plan
             success(
-              'Recipe created! However, we could not add it to your meal plan. You can add it manually from the Meal Plan page.'
+              isExistingDuplicate
+                ? 'Recipe already exists! However, we could not add it to your meal plan. You can add it manually from the Meal Plan page.'
+                : 'Recipe created! However, we could not add it to your meal plan. You can add it manually from the Meal Plan page.'
             );
           }
-        } else {
-          // Show success toast for just recipe creation
+        } else if (result) {
           success('Recipe created successfully!');
         }
 

--- a/apps/frontend/src/pages/RecipesNewPage.tsx
+++ b/apps/frontend/src/pages/RecipesNewPage.tsx
@@ -484,18 +484,31 @@ const RecipesNewPage: FC = () => {
 
       // Re-read duplicateInfo from the store: set when addRecipe encounters a 409.
       const currentDuplicateInfo = useRecipeStore.getState().duplicateInfo;
+      const existingDuplicateRecipeId =
+        currentDuplicateInfo?.existing_recipe_id ?? undefined;
 
-      // Resolve the recipe ID: newly created, or an exact-duplicate's existing ID so
-      // the meal plan flow can still proceed without user friction.
+      // Resolve the recipe ID: newly created, or an exact-duplicate's existing ID.
       const createdRecipeId: string | undefined =
         result && typeof result === 'object' && 'id' in result
           ? ((result as { id?: string | null }).id ?? undefined)
-          : (currentDuplicateInfo?.existing_recipe_id ?? undefined);
+          : existingDuplicateRecipeId;
 
-      const isExistingDuplicate = !result && !!createdRecipeId;
+      // Only auto-proceed through the duplicate path when in the assistant / meal-plan
+      // flow (proposalKey or mealPlanDate present). Outside that context let the
+      // existing duplicate modal handle the UX as before.
+      const proposalKey = searchParams.get('proposalKey');
+      const mealPlanDate = searchParams.get('mealPlanDate');
+      const isAssistantFlow = !!proposalKey || !!mealPlanDate;
+      const isExistingDuplicate =
+        !result && !!existingDuplicateRecipeId && isAssistantFlow;
 
       if (result || isExistingDuplicate) {
-        const proposalKey = searchParams.get('proposalKey');
+        // Clear duplicate state before navigating to prevent the duplicate-details
+        // useEffect from firing after unmount and briefly opening the modal.
+        if (isExistingDuplicate) {
+          clearDuplicateState();
+        }
+
         const chatConversationId =
           searchParams.get('chatConversationId') ?? undefined;
         const returnToAssistant =
@@ -504,24 +517,22 @@ const RecipesNewPage: FC = () => {
           markMealProposalSavedToBook(proposalKey);
         }
 
-        if (proposalKey) {
-          useChatStore
-            .getState()
-            .appendLocalAssistantMessage(
-              isExistingDuplicate
-                ? 'This recipe is already in your recipe book. Adding it to your meal plan now.'
-                : 'Recipe saved to your recipe book. If you selected a meal plan day, I\u2019ll add it next.',
-              chatConversationId
-            );
-        }
-
-        // Check if we should add this recipe to a meal plan
-        const mealPlanDate = searchParams.get('mealPlanDate');
         const mealPlanDayLabel = searchParams.get('mealPlanDayLabel');
-
         let nextPath: string = '/recipes';
 
         if (mealPlanDate && createdRecipeId) {
+          // Send assistant message before attempting the meal entry so the user
+          // sees accurate messaging about what is actually happening.
+          if (proposalKey) {
+            useChatStore
+              .getState()
+              .appendLocalAssistantMessage(
+                isExistingDuplicate
+                  ? 'This recipe is already in your recipe book. Adding it to your meal plan now.'
+                  : 'Recipe saved to your recipe book. Adding it to your meal plan now.',
+                chatConversationId
+              );
+          }
           try {
             await createMealEntry({
               plannedForDate: mealPlanDate,
@@ -555,8 +566,21 @@ const RecipesNewPage: FC = () => {
                 : 'Recipe created! However, we could not add it to your meal plan. You can add it manually from the Meal Plan page.'
             );
           }
-        } else if (result) {
-          success('Recipe created successfully!');
+        } else {
+          // No meal plan date — just save the recipe.
+          if (proposalKey) {
+            useChatStore
+              .getState()
+              .appendLocalAssistantMessage(
+                isExistingDuplicate
+                  ? 'This recipe is already in your recipe book.'
+                  : 'Recipe saved to your recipe book. If you selected a meal plan day, I’ll add it next.',
+                chatConversationId
+              );
+          }
+          if (result) {
+            success('Recipe created successfully!');
+          }
         }
 
         navigate(nextPath);

--- a/apps/frontend/src/pages/__tests__/RecipesNewPage.test.tsx
+++ b/apps/frontend/src/pages/__tests__/RecipesNewPage.test.tsx
@@ -2,6 +2,13 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// vi.mock factories are hoisted to the top of the file by Vitest's transform.
+// Variables used inside those factories must be declared with vi.hoisted so
+// they're initialised before the hoisted mock registrations run.
+const createMealEntryMock = vi.hoisted(() => vi.fn());
+const navigateMock = vi.hoisted(() => vi.fn());
+const clearDuplicateMock = vi.hoisted(() => vi.fn());
+
 // Basic stable mocks for modules used by the page
 vi.mock('../../stores/useRecipeStore', () => ({
   useRecipeStore: () => ({
@@ -68,7 +75,7 @@ describe('RecipesNewPage (minimal)', () => {
   it('shows validation alert when submitting without ingredients', async () => {
     // Ensure we have a fresh module instance without any AI suggestion
     vi.resetModules();
-    vi.mock('../../stores/useRecipeStore', () => ({
+    vi.doMock('../../stores/useRecipeStore', () => ({
       useRecipeStore: () => ({
         addRecipe: vi.fn().mockResolvedValue(true),
         formSuggestion: null,
@@ -112,7 +119,7 @@ describe('RecipesNewPage (minimal)', () => {
     vi.resetModules();
 
     // use the module-scoped `suggestion` defined above
-    vi.mock('../../stores/useRecipeStore', () => ({
+    vi.doMock('../../stores/useRecipeStore', () => ({
       useRecipeStore: () => ({
         addRecipe: vi.fn().mockResolvedValue(true),
         formSuggestion: suggestion,
@@ -134,9 +141,6 @@ describe('RecipesNewPage (minimal)', () => {
 });
 
 describe('RecipesNewPage - duplicate recipe handling', () => {
-  const navigateMock = vi.fn();
-  const createMealEntryMock = vi.fn().mockResolvedValue({ id: 'meal-1' });
-
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
@@ -152,7 +156,7 @@ describe('RecipesNewPage - duplicate recipe handling', () => {
   });
 
   it('proceeds with meal plan entry using existing_recipe_id when in assistant flow (409 duplicate)', async () => {
-    vi.mock('../../stores/useRecipeStore', () => ({
+    vi.doMock('../../stores/useRecipeStore', () => ({
       useRecipeStore: () => ({
         addRecipe: vi.fn().mockResolvedValue(null), // 409 → null
         formSuggestion: null,
@@ -168,10 +172,10 @@ describe('RecipesNewPage - duplicate recipe handling', () => {
       // Static getState used inside the handler
       __esModule: true,
     }));
-    vi.mock('../../api/endpoints/mealPlans', () => ({
+    vi.doMock('../../api/endpoints/mealPlans', () => ({
       createMealEntry: createMealEntryMock,
     }));
-    vi.mock('react-router-dom', () => ({
+    vi.doMock('react-router-dom', () => ({
       useNavigate: () => navigateMock,
       useSearchParams: () => [
         new URLSearchParams('proposalKey=test-key&mealPlanDate=2026-04-14'),
@@ -189,8 +193,7 @@ describe('RecipesNewPage - duplicate recipe handling', () => {
   });
 
   it('shows duplicate modal when NOT in assistant flow (no proposalKey, no mealPlanDate)', async () => {
-    const clearDuplicateMock = vi.fn();
-    vi.mock('../../stores/useRecipeStore', () => ({
+    vi.doMock('../../stores/useRecipeStore', () => ({
       useRecipeStore: () => ({
         addRecipe: vi.fn().mockResolvedValue(null),
         formSuggestion: null,
@@ -205,7 +208,7 @@ describe('RecipesNewPage - duplicate recipe handling', () => {
       }),
       __esModule: true,
     }));
-    vi.mock('react-router-dom', () => ({
+    vi.doMock('react-router-dom', () => ({
       useNavigate: () => navigateMock,
       // No proposalKey, no mealPlanDate → normal duplicate flow
       useSearchParams: () => [new URLSearchParams(), vi.fn()],

--- a/apps/frontend/src/pages/__tests__/RecipesNewPage.test.tsx
+++ b/apps/frontend/src/pages/__tests__/RecipesNewPage.test.tsx
@@ -9,6 +9,20 @@ const createMealEntryMock = vi.hoisted(() => vi.fn());
 const navigateMock = vi.hoisted(() => vi.fn());
 const clearDuplicateMock = vi.hoisted(() => vi.fn());
 
+// Mutable state shared between the hook mock and getState() so addRecipe can
+// simulate setting duplicateInfo (as the real Zustand store does on 409).
+const recipeStoreState = vi.hoisted(
+  () =>
+    ({
+      duplicateInfo: null,
+    }) as {
+      duplicateInfo: {
+        existing_recipe_id: string;
+        similar_recipes: unknown[];
+      } | null;
+    }
+);
+
 // Basic stable mocks for modules used by the page
 vi.mock('../../stores/useRecipeStore', () => ({
   useRecipeStore: () => ({
@@ -32,12 +46,24 @@ vi.mock('react-router-dom', () => ({
   useSearchParams: () => [new URLSearchParams(), vi.fn()],
 }));
 vi.mock('../../components/ui/useToast', () => ({
-  useToast: () => ({ success: vi.fn() }),
+  useToast: () => ({ success: vi.fn(), info: vi.fn() }),
 }));
 vi.mock('../../hooks/usePasteSplit', () => ({
   usePasteSplit: () => ({
     pasteSplitModal: { isOpen: false, candidateSteps: [], originalContent: '' },
   }),
+}));
+vi.mock('../../stores/useChatStore', () => ({
+  useChatStore: Object.assign(() => ({}), {
+    getState: () => ({ appendLocalAssistantMessage: vi.fn() }),
+  }),
+}));
+vi.mock('../../utils/mealProposalStatus', () => ({
+  markMealProposalSavedToBook: vi.fn(),
+  markMealProposalAddedToPlan: vi.fn(),
+}));
+vi.mock('../../api/endpoints/recipes', () => ({
+  getRecipeById: vi.fn().mockResolvedValue(null),
 }));
 
 // Shared AI suggestion used by tests that mock the recipe store
@@ -145,8 +171,10 @@ describe('RecipesNewPage - duplicate recipe handling', () => {
     vi.resetModules();
     vi.clearAllMocks();
     navigateMock.mockReset();
+    clearDuplicateMock.mockReset();
     createMealEntryMock.mockReset();
     createMealEntryMock.mockResolvedValue({ id: 'meal-1' });
+    recipeStoreState.duplicateInfo = null;
     try {
       window.localStorage.clear();
       window.sessionStorage.clear();
@@ -156,22 +184,30 @@ describe('RecipesNewPage - duplicate recipe handling', () => {
   });
 
   it('proceeds with meal plan entry using existing_recipe_id when in assistant flow (409 duplicate)', async () => {
-    vi.doMock('../../stores/useRecipeStore', () => ({
-      useRecipeStore: () => ({
-        addRecipe: vi.fn().mockResolvedValue(null), // 409 → null
+    // addRecipe simulates a 409: sets duplicateInfo in the shared store state
+    // and returns null so the component reads duplicateInfo via getState().
+    const addRecipeMock = vi.fn().mockImplementation(async () => {
+      recipeStoreState.duplicateInfo = {
+        existing_recipe_id: 'existing-uuid-123',
+        similar_recipes: [],
+      };
+      return null;
+    });
+
+    vi.doMock('../../stores/useRecipeStore', () => {
+      const useRecipeStore: any = () => ({
+        addRecipe: addRecipeMock,
         formSuggestion: null,
         isAISuggestion: false,
         clearFormSuggestion: vi.fn(),
-        duplicateInfo: {
-          existing_recipe_id: 'existing-uuid-123',
-          similar_recipes: [],
-        },
+        duplicateInfo: null, // null on mount so the modal does not open immediately
         forceCreateRecipe: vi.fn(),
         clearDuplicateState: vi.fn(),
-      }),
-      // Static getState used inside the handler
-      __esModule: true,
-    }));
+      });
+      // getState() returns the live state so the submit handler sees the 409 duplicate info
+      useRecipeStore.getState = () => recipeStoreState;
+      return { useRecipeStore };
+    });
     vi.doMock('../../api/endpoints/mealPlans', () => ({
       createMealEntry: createMealEntryMock,
     }));
@@ -186,27 +222,55 @@ describe('RecipesNewPage - duplicate recipe handling', () => {
     const { default: Page } = await import('../RecipesNewPage');
     render((<Page />) as any);
 
-    // The page should not show the duplicate modal (auto-proceed path taken)
+    // Fill required fields and submit
+    await userEvent.type(screen.getByLabelText(/Recipe Name/i), 'Test Recipe');
+    await userEvent.type(screen.getByLabelText(/Ingredient 1/i), 'Flour');
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /Step 1/i }),
+      'Mix everything'
+    );
+    await userEvent.click(screen.getByRole('button', { name: /save recipe/i }));
+
+    // The submit handler should use the existing_recipe_id from the 409 response
+    // to call createMealEntry, then navigate away.
     await waitFor(() => {
-      expect(screen.queryByRole('dialog')).toBeNull();
+      expect(createMealEntryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipeId: 'existing-uuid-123',
+          plannedForDate: '2026-04-14',
+        })
+      );
     });
+    expect(navigateMock).toHaveBeenCalled();
+    // Duplicate modal should not be shown (auto-proceed path taken)
+    expect(screen.queryByRole('dialog')).toBeNull();
   });
 
-  it('shows duplicate modal when NOT in assistant flow (no proposalKey, no mealPlanDate)', async () => {
-    vi.doMock('../../stores/useRecipeStore', () => ({
-      useRecipeStore: () => ({
-        addRecipe: vi.fn().mockResolvedValue(null),
+  it('does not auto-proceed when NOT in assistant flow (no proposalKey, no mealPlanDate)', async () => {
+    // addRecipe simulates a 409: sets duplicateInfo and returns null.
+    const addRecipeMock = vi.fn().mockImplementation(async () => {
+      recipeStoreState.duplicateInfo = {
+        existing_recipe_id: 'existing-uuid-456',
+        similar_recipes: [],
+      };
+      return null;
+    });
+
+    vi.doMock('../../stores/useRecipeStore', () => {
+      const useRecipeStore: any = () => ({
+        addRecipe: addRecipeMock,
         formSuggestion: null,
         isAISuggestion: false,
         clearFormSuggestion: vi.fn(),
-        duplicateInfo: {
-          existing_recipe_id: 'existing-uuid-456',
-          similar_recipes: [],
-        },
+        duplicateInfo: null,
         forceCreateRecipe: vi.fn(),
         clearDuplicateState: clearDuplicateMock,
-      }),
-      __esModule: true,
+      });
+      useRecipeStore.getState = () => recipeStoreState;
+      return { useRecipeStore };
+    });
+    vi.doMock('../../api/endpoints/mealPlans', () => ({
+      createMealEntry: createMealEntryMock,
     }));
     vi.doMock('react-router-dom', () => ({
       useNavigate: () => navigateMock,
@@ -217,9 +281,21 @@ describe('RecipesNewPage - duplicate recipe handling', () => {
     const { default: Page } = await import('../RecipesNewPage');
     render((<Page />) as any);
 
-    // Should NOT navigate away — duplicate modal should take over
+    // Fill required fields and submit
+    await userEvent.type(screen.getByLabelText(/Recipe Name/i), 'Test Recipe');
+    await userEvent.type(screen.getByLabelText(/Ingredient 1/i), 'Flour');
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /Step 1/i }),
+      'Mix everything'
+    );
+    await userEvent.click(screen.getByRole('button', { name: /save recipe/i }));
+
+    // Without assistant flow params, the auto-proceed path is NOT taken:
+    // createMealEntry must not be called and the page must not navigate away.
     await waitFor(() => {
-      expect(navigateMock).not.toHaveBeenCalled();
+      expect(addRecipeMock).toHaveBeenCalled();
     });
+    expect(createMealEntryMock).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/pages/__tests__/RecipesNewPage.test.tsx
+++ b/apps/frontend/src/pages/__tests__/RecipesNewPage.test.tsx
@@ -132,3 +132,91 @@ describe('RecipesNewPage (minimal)', () => {
     expect(screen.getByDisplayValue('Do this')).toBeTruthy();
   });
 });
+
+describe('RecipesNewPage - duplicate recipe handling', () => {
+  const navigateMock = vi.fn();
+  const createMealEntryMock = vi.fn().mockResolvedValue({ id: 'meal-1' });
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    navigateMock.mockReset();
+    createMealEntryMock.mockReset();
+    createMealEntryMock.mockResolvedValue({ id: 'meal-1' });
+    try {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('proceeds with meal plan entry using existing_recipe_id when in assistant flow (409 duplicate)', async () => {
+    vi.mock('../../stores/useRecipeStore', () => ({
+      useRecipeStore: () => ({
+        addRecipe: vi.fn().mockResolvedValue(null), // 409 → null
+        formSuggestion: null,
+        isAISuggestion: false,
+        clearFormSuggestion: vi.fn(),
+        duplicateInfo: {
+          existing_recipe_id: 'existing-uuid-123',
+          similar_recipes: [],
+        },
+        forceCreateRecipe: vi.fn(),
+        clearDuplicateState: vi.fn(),
+      }),
+      // Static getState used inside the handler
+      __esModule: true,
+    }));
+    vi.mock('../../api/endpoints/mealPlans', () => ({
+      createMealEntry: createMealEntryMock,
+    }));
+    vi.mock('react-router-dom', () => ({
+      useNavigate: () => navigateMock,
+      useSearchParams: () => [
+        new URLSearchParams('proposalKey=test-key&mealPlanDate=2026-04-14'),
+        vi.fn(),
+      ],
+    }));
+
+    const { default: Page } = await import('../RecipesNewPage');
+    render((<Page />) as any);
+
+    // The page should not show the duplicate modal (auto-proceed path taken)
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeNull();
+    });
+  });
+
+  it('shows duplicate modal when NOT in assistant flow (no proposalKey, no mealPlanDate)', async () => {
+    const clearDuplicateMock = vi.fn();
+    vi.mock('../../stores/useRecipeStore', () => ({
+      useRecipeStore: () => ({
+        addRecipe: vi.fn().mockResolvedValue(null),
+        formSuggestion: null,
+        isAISuggestion: false,
+        clearFormSuggestion: vi.fn(),
+        duplicateInfo: {
+          existing_recipe_id: 'existing-uuid-456',
+          similar_recipes: [],
+        },
+        forceCreateRecipe: vi.fn(),
+        clearDuplicateState: clearDuplicateMock,
+      }),
+      __esModule: true,
+    }));
+    vi.mock('react-router-dom', () => ({
+      useNavigate: () => navigateMock,
+      // No proposalKey, no mealPlanDate → normal duplicate flow
+      useSearchParams: () => [new URLSearchParams(), vi.fn()],
+    }));
+
+    const { default: Page } = await import('../RecipesNewPage');
+    render((<Page />) as any);
+
+    // Should NOT navigate away — duplicate modal should take over
+    await waitFor(() => {
+      expect(navigateMock).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Two bugs causing the Accept button on meal proposals to fail silently or show errors:

### Bug 1: Missing trailing slash → 422 on `/api/v1/meals`

`createMealEntry` was sending `POST /api/v1/meals` (no trailing slash). FastAPI 307-redirects to `/api/v1/meals/` and the POST body was dropped in some environments, resulting in a 422 for missing `planned_for_date`.

**Fix:** Added trailing slash to `'/api/v1/meals/'`.

### Bug 2: Duplicate recipe (409) silently breaks meal plan flow

When the assistant sent the user to `RecipesNewPage` to save a recipe that already existed, the backend returns a 409 with `existing_recipe_id`. But `RecipesNewPage` only checked `if (result)` — so the `existing_recipe_id` was never used and the meal plan entry was never created.

**Fix:** After `addRecipe` returns `null`, read `duplicateInfo` from the store. If `existing_recipe_id` is present, use it to proceed with the meal plan entry.