### PR TITLE
fix(application): update Gemini model from preview to GA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,13 +140,13 @@ AZURE_OPENAI_API_VERSION=2024-10-01-preview
 CHAT_MODEL=gemini-3-flash-preview        # Or: gpt-4o-mini (Azure)
 
 # Multimodal model for image-based recipe extraction (must support vision)
-MULTIMODAL_MODEL=gemini-3.1-flash-lite-preview   # Or: gpt-4o (Azure)
+MULTIMODAL_MODEL=gemini-3.1-flash-lite            # Or: gpt-4o (Azure)
 
 # Text model for fast text-only tasks (for example: context generation,
 # URL recipe extraction, and title generation)
-TEXT_MODEL=gemini-3.1-flash-lite-preview         # Or: gpt-4o-mini (Azure)
+TEXT_MODEL=gemini-3.1-flash-lite                  # Or: gpt-4o-mini (Azure)
 
-# Preview guardrail: re-check Google's models.list + models/pricing docs before rollout.
+# Guardrail: re-check Google's models.list + models/pricing docs before rollout.
 # Stable rollback pair:
 # CHAT_MODEL=gemini-2.5-pro
 # MULTIMODAL_MODEL=gemini-2.5-flash-lite

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -179,8 +179,8 @@ GEMINI_API_KEY=your-gemini-api-key
 # Assistant standard tier
 CHAT_MODEL=gemini-3-flash-preview
 # URL + image import tier
-MULTIMODAL_MODEL=gemini-3.1-flash-lite-preview
-TEXT_MODEL=gemini-3.1-flash-lite-preview
+MULTIMODAL_MODEL=gemini-3.1-flash-lite
+TEXT_MODEL=gemini-3.1-flash-lite
 EMBEDDING_MODEL=gemini-embedding-001
 ```
 
@@ -199,10 +199,10 @@ When `LLM_PROVIDER=azure_openai`, the following features use Azure OpenAI:
 | Feature | Configuration Variable | Default (Gemini) |
 |---------|----------------------|------------------|
 | Chat Agent | `CHAT_MODEL` | gemini-3-flash-preview |
-| Recipe Extraction (URL) | `TEXT_MODEL` | gemini-3.1-flash-lite-preview |
-| Recipe Extraction (Image) | `MULTIMODAL_MODEL` | gemini-3.1-flash-lite-preview |
-| Title Generation | `TEXT_MODEL` | gemini-3.1-flash-lite-preview |
-| Context Generation | `TEXT_MODEL` | gemini-3.1-flash-lite-preview |
+| Recipe Extraction (URL) | `TEXT_MODEL` | gemini-3.1-flash-lite |
+| Recipe Extraction (Image) | `MULTIMODAL_MODEL` | gemini-3.1-flash-lite |
+| Title Generation | `TEXT_MODEL` | gemini-3.1-flash-lite |
+| Context Generation | `TEXT_MODEL` | gemini-3.1-flash-lite |
 | Semantic Search | `EMBEDDING_MODEL` | gemini-embedding-001 |
 
 All providers support tool calling and structured outputs.

--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -42,17 +42,17 @@ class Settings(BaseSettings):
     # IMPORTANT: When using Azure OpenAI, override ALL model names to match
     # your Azure deployment names (e.g., gpt-4o-mini, text-embedding-3-small)
     # The defaults below are Gemini-specific and will not work with Azure.
-    # Gemini 3 preview defaults:
+    # Gemini 3 defaults:
     # - assistant/chat uses gemini-3-flash-preview
-    # - URL/image extraction uses gemini-3.1-flash-lite-preview
-    # Stable rollback pair if preview quality/rate limits regress:
+    # - URL/image extraction uses gemini-3.1-flash-lite
+    # Stable rollback pair if quality/rate limits regress:
     # - CHAT_MODEL=gemini-2.5-pro
     # - TEXT_MODEL=gemini-2.5-flash-lite
     # - MULTIMODAL_MODEL=gemini-2.5-flash-lite
     CHAT_MODEL: str = "gemini-3-flash-preview"  # General chat/completion model
-    MULTIMODAL_MODEL: str = "gemini-3.1-flash-lite-preview"  # Image/vision tasks
+    MULTIMODAL_MODEL: str = "gemini-3.1-flash-lite"  # Image/vision tasks
     EMBEDDING_MODEL: str = "gemini-embedding-001"  # Semantic embeddings
-    TEXT_MODEL: str = "gemini-3.1-flash-lite-preview"  # Fast text tasks (context gen)
+    TEXT_MODEL: str = "gemini-3.1-flash-lite"  # Fast text tasks (context gen)
 
     # Provider-specific API credentials
     # Gemini configuration

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -330,8 +330,8 @@ module containerApps 'modules/containerapps.bicep' = {
     llmProvider: useAzureOpenAI ? 'azure_openai' : 'gemini'
     // Model names - for Azure OpenAI, these must match deployment names on the target resource.
     chatModel: useAzureOpenAI ? azureChatModel : 'gemini-3-flash-preview'
-    multimodalModel: useAzureOpenAI ? azureMultimodalModel : 'gemini-3.1-flash-lite-preview'
-    textModel: useAzureOpenAI ? azureTextModel : 'gemini-3.1-flash-lite-preview'
+    multimodalModel: useAzureOpenAI ? azureMultimodalModel : 'gemini-3.1-flash-lite'
+    textModel: useAzureOpenAI ? azureTextModel : 'gemini-3.1-flash-lite'
     embeddingModel: useAzureOpenAI ? azureEmbeddingModel : 'gemini-embedding-001'
     enableObservability: true
     tags: commonTags

--- a/infra/modules/containerapps.bicep
+++ b/infra/modules/containerapps.bicep
@@ -76,10 +76,10 @@ param llmProvider string = 'gemini'
 param chatModel string = 'gemini-3-flash-preview'
 
 @description('Multimodal model name for image/vision tasks')
-param multimodalModel string = 'gemini-3.1-flash-lite-preview'
+param multimodalModel string = 'gemini-3.1-flash-lite'
 
 @description('Text model name for fast text tasks')
-param textModel string = 'gemini-3.1-flash-lite-preview'
+param textModel string = 'gemini-3.1-flash-lite'
 
 @description('Embedding model name for semantic search')
 param embeddingModel string = 'gemini-embedding-001'


### PR DESCRIPTION
## Summary

Update `gemini-3.1-flash-lite-preview` → `gemini-3.1-flash-lite` across all config, infrastructure, and documentation files.

Google is discontinuing the preview model on **May 25, 2026**. The GA model uses the identical architecture — no prompt or logic changes required, only the model identifier string.

## Changes

- **`apps/backend/src/core/config.py`** — Update `MULTIMODAL_MODEL` and `TEXT_MODEL` defaults + comments
- **`.env.example`** — Update example model values
- **`infra/main.bicep`** — Update Gemini model defaults
- **`infra/modules/containerapps.bicep`** — Update `multimodalModel` and `textModel` params
- **`apps/backend/README.md`** — Update documentation references

## Validation

- All pre-commit hooks pass (ruff, format, secrets detection)
- `make lint` ✅
- `make type-check` ✅ (mypy + tsc)
- `make test` ✅ (704 tests pass)

Closes #478