### PR TITLE
Fix grocery lists dropping unitless ingredients

### DIFF
--- a/apps/backend/src/api/v1/grocery_lists.py
+++ b/apps/backend/src/api/v1/grocery_lists.py
@@ -28,7 +28,8 @@ logger = logging.getLogger(__name__)
         "Generate a grocery list for the authenticated user based on their meal plan "
         "within the specified date range. Aggregates ingredients from all recipes "
         "planned for the given period, excluding optional ingredients and meals "
-        "marked as 'eating out'."
+        "marked as 'eating out'. Ingredients without a stored unit are included "
+        "with an empty quantity_unit string so the response contract remains stable."
     ),
     responses={
         200: {"description": "Grocery list generated successfully"},

--- a/apps/backend/src/crud/grocery_lists.py
+++ b/apps/backend/src/crud/grocery_lists.py
@@ -85,8 +85,6 @@ class GroceryListCRUD:
                     RecipeIngredient.is_optional.is_(False),
                     # Must have quantity
                     RecipeIngredient.quantity_value.is_not(None),
-                    # Must have unit
-                    RecipeIngredient.quantity_unit.is_not(None),
                 )
             )
         )
@@ -105,7 +103,8 @@ class GroceryListCRUD:
         )
 
         for row in ingredient_rows:
-            key = (row.ingredient_id, row.quantity_unit)
+            quantity_unit = row.quantity_unit or ""
+            key = (row.ingredient_id, quantity_unit)
             agg = aggregated[key]
 
             # Add to quantity (convert to float for aggregation)

--- a/apps/backend/tests/test_grocery_lists_api.py
+++ b/apps/backend/tests/test_grocery_lists_api.py
@@ -247,6 +247,81 @@ class TestGroceryListAPI:
         assert "Test Recipe" in tomato_ingredient["recipes"]
 
     @pytest.mark.asyncio
+    async def test_generate_grocery_list_includes_unitless_ingredients(
+        self, grocery_client
+    ):
+        """Test that ingredients without units still appear in the grocery list."""
+        client, session = grocery_client
+
+        demo_user = User(
+            id=uuid4(),
+            username="demo",
+            email="demo@tests.local",
+            hashed_password="x",
+        )
+        session.add(demo_user)
+        await session.commit()
+
+        recipe = Recipe(
+            id=uuid4(),
+            user_id=demo_user.id,
+            name="Unitless Recipe",
+            prep_time_minutes=10,
+            cook_time_minutes=15,
+        )
+        session.add(recipe)
+
+        ingredient = Ingredient(
+            id=uuid4(),
+            user_id=demo_user.id,
+            ingredient_name="Eggplant",
+        )
+        session.add(ingredient)
+
+        recipe_ingredient = RecipeIngredient(
+            id=uuid4(),
+            recipe_id=recipe.id,
+            ingredient_id=ingredient.id,
+            quantity_value=1.0,
+            quantity_unit=None,
+            is_optional=False,
+        )
+        session.add(recipe_ingredient)
+
+        today = date.today()
+        meal = Meal(
+            id=uuid4(),
+            user_id=demo_user.id,
+            recipe_id=recipe.id,
+            planned_for_date=today,
+            meal_type="dinner",
+            is_leftover=False,
+            is_eating_out=False,
+        )
+        session.add(meal)
+        await session.commit()
+
+        response = await client.post(
+            "/api/v1/grocery-lists",
+            json={
+                "start_date": today.isoformat(),
+                "end_date": today.isoformat(),
+            },
+        )
+
+        assert response.status_code == 200
+        grocery_list = response.json()["data"]
+
+        assert grocery_list["total_meals"] == 1
+        assert len(grocery_list["ingredients"]) == 1
+
+        unitless_ingredient = grocery_list["ingredients"][0]
+        assert unitless_ingredient["name"] == "Eggplant"
+        assert unitless_ingredient["quantity_value"] == 1.0
+        assert unitless_ingredient["quantity_unit"] == ""
+        assert unitless_ingredient["recipes"] == ["Unitless Recipe"]
+
+    @pytest.mark.asyncio
     async def test_generate_grocery_list_empty_date_range(self, grocery_client):
         """Test grocery list generation with no meals in date range."""
         client, session = grocery_client


### PR DESCRIPTION
Closes #485

Keep unitless grocery-list ingredients visible by preserving rows with a missing `quantity_unit` and serializing that field as an empty string. This matches the existing frontend contract and adds regression coverage for the missing-unit case.