### PR TITLE
fix(application): preserve structural containers in html cleanup

### DIFF
--- a/apps/backend/src/services/ai/html_extractor.py
+++ b/apps/backend/src/services/ai/html_extractor.py
@@ -443,6 +443,11 @@ class HTMLExtractionService:
         combined_selector = ",".join(self.BOILERPLATE_SELECTORS)
         try:
             for element in soup.select(combined_selector):
+                # Broad substring selectors like [class*='sidebar'] can match
+                # structural containers (for example <body class="has-sidebar">)
+                # and wipe the entire document. Preserve root/content wrappers.
+                if element.name in {"html", "body", "main", "article"}:
+                    continue
                 element.decompose()
         except Exception as e:
             # Log and continue if selector processing fails

--- a/apps/backend/tests/ai/test_html_extractor.py
+++ b/apps/backend/tests/ai/test_html_extractor.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 import httpx
 import pytest
+from bs4 import BeautifulSoup
 from fastapi import HTTPException
 
 from services.ai.html_extractor import HTMLExtractionService
@@ -154,3 +155,34 @@ async def test_empty_response():
         mock_async.get.return_value = mock_resp
         result = await extractor.fetch_and_sanitize("https://example.com/empty")
         assert result == ""
+
+
+def test_remove_boilerplate_preserves_structural_containers() -> None:
+    extractor = HTMLExtractionService()
+    html = """
+        <html>
+            <body class="has-sidebar single-post">
+                <main>
+                    <article>
+                        <div class="entry-content">
+                            <h1>Creamy Mediterranean Chicken</h1>
+                            <p>Chicken, cream, tomatoes, and spinach.</p>
+                        </div>
+                        <aside class="recipe-sidebar">
+                            <p>Newsletter signup</p>
+                        </aside>
+                    </article>
+                </main>
+            </body>
+        </html>
+        """
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    extractor._remove_boilerplate(soup)
+
+    result = str(soup)
+    assert "Creamy Mediterranean Chicken" in result
+    assert "Chicken, cream, tomatoes, and spinach." in result
+    assert "Newsletter signup" not in result
+    assert soup.body is not None


### PR DESCRIPTION
## Summary
- preserve structural containers during boilerplate removal in the HTML sanitizer
- add a regression test for pages that use `body.has-sidebar`
- keep URL extraction from collapsing into empty failure drafts on affected recipe sites

## Validation
- `uv run pytest tests/ai/test_html_extractor.py -q`
- direct repro against `https://www.kyleecooks.com/creamy-mediterranean-chicken-skillet/`

Closes #487