### PR TITLE
fix(application): recover assistant meal proposal flow

### DIFF
--- a/apps/backend/src/api/v1/chat.py
+++ b/apps/backend/src/api/v1/chat.py
@@ -1691,7 +1691,11 @@ async def stream_chat_message(  # noqa: C901
                 event="error",
                 conversation_id=conversation_id,
                 message_id=message_id,
-                data={"message": error_message},
+                data={
+                    "error_code": "assistant_error",
+                    "detail": error_message,
+                    "message": error_message,
+                },
             ).to_sse()
         finally:
             yield ChatSseEvent(

--- a/apps/backend/src/schemas/chat_content.py
+++ b/apps/backend/src/schemas/chat_content.py
@@ -96,7 +96,7 @@ class MealProposalBlock(BaseModel):
     """
 
     type: Literal["meal_proposal"]
-    proposal_id: str  # For tracking accept/reject (e.g., "2026-01-26-proposal")
+    proposal_id: str  # Instance-scoped identifier (e.g., "2026-01-26-proposal-<uuid>")
     date: str  # ISO date (YYYY-MM-DD)
     day_label: str  # Human-friendly day name ("Monday", "Taco Tuesday", etc.)
 

--- a/apps/backend/src/services/chat_agent/tools/meal_proposals.py
+++ b/apps/backend/src/services/chat_agent/tools/meal_proposals.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from uuid import uuid4
 
 from pydantic_ai import RunContext
 
@@ -67,7 +68,7 @@ async def tool_propose_meal_for_day(
         "type": "meal_proposal",
         "date": date,
         "day_label": day_label,
-        "proposal_id": f"{date}-proposal",
+        "proposal_id": f"{date}-proposal-{uuid4().hex}",
         "existing_recipe": None,
         "new_recipe": None,
         "is_leftover": is_leftover,

--- a/apps/backend/tests/services/test_meal_proposal_tool.py
+++ b/apps/backend/tests/services/test_meal_proposal_tool.py
@@ -74,7 +74,7 @@ class TestProposeMealForDayTool:
         assert proposal["type"] == "meal_proposal"
         assert proposal["date"] == "2026-01-26"
         assert proposal["day_label"] == "Sunday"
-        assert proposal["proposal_id"] == "2026-01-26-proposal"
+        assert proposal["proposal_id"].startswith("2026-01-26-proposal-")
         assert proposal["existing_recipe"]["id"] == recipe_id
         assert proposal["existing_recipe"]["title"] == "Mom's Lasagna"
         assert (
@@ -215,7 +215,19 @@ class TestProposeMealForDayTool:
 
         # Assert
         proposal = result["meal_proposal"]
-        assert proposal["proposal_id"] == "2026-02-01-proposal"
+        second_result = await tool_propose_meal_for_day(
+            ctx=ctx,
+            date="2026-02-01",
+            day_label="Saturday",
+            new_recipe_title="Test Recipe",
+            new_recipe_source_url="https://example.com/test",
+        )
+
+        assert proposal["proposal_id"].startswith("2026-02-01-proposal-")
+        assert second_result["meal_proposal"]["proposal_id"].startswith(
+            "2026-02-01-proposal-"
+        )
+        assert proposal["proposal_id"] != second_result["meal_proposal"]["proposal_id"]
 
     @pytest.mark.asyncio
     async def test_minimal_existing_recipe_proposal(self) -> None:

--- a/apps/frontend/src/api/endpoints/__tests__/chat.test.ts
+++ b/apps/frontend/src/api/endpoints/__tests__/chat.test.ts
@@ -643,6 +643,195 @@ describe('chat API endpoints', () => {
         'Network error'
       );
     });
+
+    it('calls onError with stream_closed when stream ends without terminal event', async () => {
+      const callbacks = {
+        onError: vi.fn(),
+        onDelta: vi.fn(),
+      };
+
+      const encoder = new TextEncoder();
+      const deltaEvent = {
+        event: 'message.delta',
+        conversation_id: 'conv-123',
+        message_id: 'msg-123',
+        data: { delta: 'partial' },
+      };
+      const chunk = encoder.encode(
+        'data: ' + JSON.stringify(deltaEvent) + '\n\n'
+      );
+
+      let readCalls = 0;
+      const reader = {
+        read: async () => {
+          readCalls += 1;
+          if (readCalls === 1) return { value: chunk, done: false };
+          // Stream ends without done/error event
+          return { value: undefined, done: true };
+        },
+        cancel: vi.fn(),
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        body: { getReader: () => reader },
+      });
+
+      await streamChatMessage(null, 'Hello', callbacks);
+
+      expect(callbacks.onDelta).toHaveBeenCalledWith('partial', 'msg-123');
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        'stream_closed',
+        'The assistant connection closed unexpectedly. Please try again.'
+      );
+    });
+
+    it('does not call onError with stream_closed when terminal event was received', async () => {
+      const callbacks = {
+        onError: vi.fn(),
+        onDone: vi.fn(),
+      };
+
+      const encoder = new TextEncoder();
+      const doneEvent = {
+        event: 'done',
+        conversation_id: 'conv-123',
+        message_id: null,
+        data: {},
+      };
+      const chunk = encoder.encode(
+        'data: ' + JSON.stringify(doneEvent) + '\n\n'
+      );
+
+      let readCalls = 0;
+      const reader = {
+        read: async () => {
+          readCalls += 1;
+          if (readCalls === 1) return { value: chunk, done: false };
+          return { value: undefined, done: true };
+        },
+        cancel: vi.fn(),
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        body: { getReader: () => reader },
+      });
+
+      await streamChatMessage(null, 'Hello', callbacks);
+
+      expect(callbacks.onDone).toHaveBeenCalled();
+      expect(callbacks.onError).not.toHaveBeenCalled();
+    });
+
+    it('calls onError with parse_error when SSE message is malformed', async () => {
+      const callbacks = {
+        onError: vi.fn(),
+      };
+
+      const encoder = new TextEncoder();
+      const chunk = encoder.encode('data: {invalid json\n\n');
+
+      let readCalls = 0;
+      const reader = {
+        read: async () => {
+          readCalls += 1;
+          if (readCalls === 1) return { value: chunk, done: false };
+          return { value: undefined, done: true };
+        },
+        cancel: vi.fn(),
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        body: { getReader: () => reader },
+      });
+
+      await streamChatMessage(null, 'Hello', callbacks);
+
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        'parse_error',
+        'Failed to process the assistant response. Please try again.'
+      );
+    });
+
+    it('uses fallback error fields when error_code/detail are missing', async () => {
+      const callbacks = {
+        onError: vi.fn(),
+      };
+
+      const encoder = new TextEncoder();
+      const errorEvent = {
+        event: 'error',
+        conversation_id: 'conv-123',
+        message_id: null,
+        data: { message: 'Something went wrong' },
+      };
+      const chunk = encoder.encode(
+        'data: ' + JSON.stringify(errorEvent) + '\n\n'
+      );
+
+      let readCalls = 0;
+      const reader = {
+        read: async () => {
+          readCalls += 1;
+          if (readCalls === 1) return { value: chunk, done: false };
+          return { value: undefined, done: true };
+        },
+        cancel: vi.fn(),
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        body: { getReader: () => reader },
+      });
+
+      await streamChatMessage(null, 'Hello', callbacks);
+
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        'assistant_error',
+        'Something went wrong'
+      );
+    });
+
+    it('uses code field as fallback for error_code', async () => {
+      const callbacks = {
+        onError: vi.fn(),
+      };
+
+      const encoder = new TextEncoder();
+      const errorEvent = {
+        event: 'error',
+        conversation_id: 'conv-123',
+        message_id: null,
+        data: { code: 'timeout', error: 'Request timed out' },
+      };
+      const chunk = encoder.encode(
+        'data: ' + JSON.stringify(errorEvent) + '\n\n'
+      );
+
+      let readCalls = 0;
+      const reader = {
+        read: async () => {
+          readCalls += 1;
+          if (readCalls === 1) return { value: chunk, done: false };
+          return { value: undefined, done: true };
+        },
+        cancel: vi.fn(),
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        body: { getReader: () => reader },
+      });
+
+      await streamChatMessage(null, 'Hello', callbacks);
+
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        'timeout',
+        'Request timed out'
+      );
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/frontend/src/api/endpoints/chat.ts
+++ b/apps/frontend/src/api/endpoints/chat.ts
@@ -123,16 +123,24 @@ export async function streamChatMessage(
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
+    let sawTerminalEvent = false;
 
     // Process the SSE stream
     while (true) {
       const { value, done } = await reader.read();
 
       if (done) {
+        if (!sawTerminalEvent) {
+          callbacks.onError?.(
+            'stream_closed',
+            'The assistant connection closed unexpectedly. Please try again.'
+          );
+        }
         break;
       }
 
       buffer += decoder.decode(value, { stream: true });
+      let shouldStopReading = false;
 
       // Process complete SSE messages (delimiter is \n\n)
       let newlineIndex;
@@ -153,12 +161,26 @@ export async function streamChatMessage(
 
           // Terminal events
           if (event.event === 'done' || event.event === 'error') {
-            reader.cancel();
+            sawTerminalEvent = true;
+            void reader.cancel();
+            shouldStopReading = true;
             break;
           }
         } catch (err) {
           logger.error('Failed to parse SSE message:', err);
+          callbacks.onError?.(
+            'parse_error',
+            'Failed to process the assistant response. Please try again.'
+          );
+          sawTerminalEvent = true;
+          void reader.cancel();
+          shouldStopReading = true;
+          break;
         }
+      }
+
+      if (shouldStopReading) {
+        break;
       }
     }
   } catch (err) {
@@ -209,8 +231,15 @@ function handleSseEvent(
     }
 
     case 'error': {
-      const errorCode = (event.data.error_code as string) || 'unknown';
-      const detail = (event.data.detail as string) || 'Unknown error';
+      const errorCode =
+        (event.data.error_code as string) ||
+        (event.data.code as string) ||
+        'assistant_error';
+      const detail =
+        (event.data.detail as string) ||
+        (event.data.message as string) ||
+        (event.data.error as string) ||
+        'Unknown error';
       callbacks.onError?.(errorCode, detail);
       break;
     }

--- a/apps/frontend/src/components/chat/__tests__/MealProposalBlock.test.tsx
+++ b/apps/frontend/src/components/chat/__tests__/MealProposalBlock.test.tsx
@@ -35,11 +35,21 @@ vi.mock('../../../stores/useChatStore', () => ({
 }));
 
 vi.mock('../../../utils/mealProposalStatus', () => ({
+  getMealProposalInstanceId: () => 'test-proposal-123',
   getMealProposalStatus: () => ({
+    version: 1,
+    phase: 'pending',
+    updatedAt: undefined,
+    proposalInstanceId: undefined,
+    recipeId: undefined,
+    returnContext: undefined,
+    lastError: undefined,
     savedToBook: false,
     addedToPlan: false,
     rejected: false,
+    canRetryAdd: false,
   }),
+  invalidateMealProposalStatus: vi.fn(),
   markMealProposalSavedToBook: vi.fn(),
   markMealProposalAddedToPlan: vi.fn(),
   markMealProposalRejected: vi.fn(),

--- a/apps/frontend/src/components/chat/__tests__/MealProposalBlock.test.tsx
+++ b/apps/frontend/src/components/chat/__tests__/MealProposalBlock.test.tsx
@@ -34,25 +34,24 @@ vi.mock('../../../stores/useChatStore', () => ({
   },
 }));
 
+const mockGetMealProposalStatus = vi.fn();
+const mockInvalidateMealProposalStatus = vi.fn();
+const mockMarkMealProposalSavedToBook = vi.fn();
+const mockMarkMealProposalAddedToPlan = vi.fn();
+const mockMarkMealProposalRejected = vi.fn();
+
 vi.mock('../../../utils/mealProposalStatus', () => ({
   getMealProposalInstanceId: () => 'test-proposal-123',
-  getMealProposalStatus: () => ({
-    version: 1,
-    phase: 'pending',
-    updatedAt: undefined,
-    proposalInstanceId: undefined,
-    recipeId: undefined,
-    returnContext: undefined,
-    lastError: undefined,
-    savedToBook: false,
-    addedToPlan: false,
-    rejected: false,
-    canRetryAdd: false,
-  }),
-  invalidateMealProposalStatus: vi.fn(),
-  markMealProposalSavedToBook: vi.fn(),
-  markMealProposalAddedToPlan: vi.fn(),
-  markMealProposalRejected: vi.fn(),
+  getMealProposalStatus: (...args: unknown[]) =>
+    mockGetMealProposalStatus(...args),
+  invalidateMealProposalStatus: (...args: unknown[]) =>
+    mockInvalidateMealProposalStatus(...args),
+  markMealProposalSavedToBook: (...args: unknown[]) =>
+    mockMarkMealProposalSavedToBook(...args),
+  markMealProposalAddedToPlan: (...args: unknown[]) =>
+    mockMarkMealProposalAddedToPlan(...args),
+  markMealProposalRejected: (...args: unknown[]) =>
+    mockMarkMealProposalRejected(...args),
 }));
 
 import { MealProposalBlock } from '../blocks/MealProposalBlock';
@@ -65,6 +64,19 @@ describe('MealProposalBlock', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    mockGetMealProposalStatus.mockReturnValue({
+      version: 1,
+      phase: 'pending',
+      updatedAt: undefined,
+      proposalInstanceId: undefined,
+      recipeId: undefined,
+      returnContext: undefined,
+      lastError: undefined,
+      savedToBook: false,
+      addedToPlan: false,
+      rejected: false,
+      canRetryAdd: false,
+    });
   });
 
   const baseBlock: MealProposalBlockType = {
@@ -294,6 +306,147 @@ describe('MealProposalBlock', () => {
 
       // Should show "Sat, Jan 25" not the previous day
       expect(screen.getByText(/Jan 25/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('persisted state recovery', () => {
+    it('renders recipe_saved state with continue button', () => {
+      mockGetMealProposalStatus.mockReturnValue({
+        version: 1,
+        phase: 'recipe_saved',
+        updatedAt: '2026-01-25T10:00:00Z',
+        proposalInstanceId: 'test-proposal-123',
+        recipeId: 'recipe-abc',
+        returnContext: undefined,
+        lastError: undefined,
+        savedToBook: true,
+        addedToPlan: false,
+        rejected: false,
+        canRetryAdd: true,
+      });
+
+      const block: MealProposalBlockType = {
+        ...baseBlock,
+        new_recipe: {
+          title: 'Beef Bourguignon',
+          source_url: 'https://example.com/beef',
+        },
+      };
+
+      renderWithRouter(<MealProposalBlock block={block} />);
+
+      expect(
+        screen.getByText(/Recipe saved to your recipe book/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Continue to Meal Plan/i })
+      ).toBeInTheDocument();
+    });
+
+    it('renders retryable_add_failure state with retry button', () => {
+      mockGetMealProposalStatus.mockReturnValue({
+        version: 1,
+        phase: 'retryable_add_failure',
+        updatedAt: '2026-01-25T10:00:00Z',
+        proposalInstanceId: 'test-proposal-123',
+        recipeId: 'recipe-abc',
+        returnContext: undefined,
+        lastError: 'meal_entry_create_failed',
+        savedToBook: true,
+        addedToPlan: false,
+        rejected: false,
+        canRetryAdd: true,
+      });
+
+      const block: MealProposalBlockType = {
+        ...baseBlock,
+        new_recipe: {
+          title: 'Beef Bourguignon',
+          source_url: 'https://example.com/beef',
+        },
+      };
+
+      renderWithRouter(<MealProposalBlock block={block} />);
+
+      expect(
+        screen.getByText(/Add to meal plan needs one more try/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Retry Add to Meal Plan/i })
+      ).toBeInTheDocument();
+    });
+
+    it('renders added_to_plan (accepted) state', () => {
+      mockGetMealProposalStatus.mockReturnValue({
+        version: 1,
+        phase: 'added_to_plan',
+        updatedAt: '2026-01-25T10:00:00Z',
+        proposalInstanceId: 'test-proposal-123',
+        recipeId: 'recipe-abc',
+        returnContext: undefined,
+        lastError: undefined,
+        savedToBook: false,
+        addedToPlan: true,
+        rejected: false,
+        canRetryAdd: false,
+      });
+
+      const block: MealProposalBlockType = {
+        ...baseBlock,
+        existing_recipe: {
+          id: 'recipe-123',
+          title: 'Classic Lasagna',
+        },
+      };
+
+      renderWithRouter(<MealProposalBlock block={block} />);
+
+      expect(screen.getByText(/Added to Saturday/i)).toBeInTheDocument();
+    });
+
+    it('renders rejected state', () => {
+      mockGetMealProposalStatus.mockReturnValue({
+        version: 1,
+        phase: 'rejected',
+        updatedAt: '2026-01-25T10:00:00Z',
+        proposalInstanceId: 'test-proposal-123',
+        recipeId: undefined,
+        returnContext: undefined,
+        lastError: undefined,
+        savedToBook: false,
+        addedToPlan: false,
+        rejected: true,
+        canRetryAdd: false,
+      });
+
+      const block: MealProposalBlockType = {
+        ...baseBlock,
+        existing_recipe: {
+          id: 'recipe-123',
+          title: 'Classic Lasagna',
+        },
+      };
+
+      renderWithRouter(<MealProposalBlock block={block} />);
+
+      expect(screen.getByText(/Rejected/i)).toBeInTheDocument();
+    });
+
+    it('calls invalidateMealProposalStatus on mount', () => {
+      const block: MealProposalBlockType = {
+        ...baseBlock,
+        existing_recipe: {
+          id: 'recipe-123',
+          title: 'Classic Lasagna',
+        },
+      };
+
+      renderWithRouter(<MealProposalBlock block={block} />);
+
+      expect(mockInvalidateMealProposalStatus).toHaveBeenCalledWith(
+        expect.any(String),
+        'test-proposal-123'
+      );
     });
   });
 });

--- a/apps/frontend/src/components/chat/blocks/MealProposalBlock.tsx
+++ b/apps/frontend/src/components/chat/blocks/MealProposalBlock.tsx
@@ -30,6 +30,7 @@ import { useChatStore } from '../../../stores/useChatStore';
 import type { MealProposalBlock as MealProposalBlockType } from '../../../types/Chat';
 import {
   getMealProposalStatus,
+  invalidateMealProposalStatus,
   markMealProposalAddedToPlan,
   markMealProposalRejected,
 } from '../../../utils/mealProposalStatus';
@@ -43,8 +44,35 @@ type ProposalState =
   | 'accepted'
   | 'rejected'
   | 'saving_to_book'
-  | 'saved_to_book'
+  | 'recipe_saved'
+  | 'retryable_add_failure'
   | 'needs_save_warning';
+
+function getProposalState(
+  status: ReturnType<typeof getMealProposalStatus>
+): ProposalState {
+  if (status.addedToPlan) {
+    return 'accepted';
+  }
+
+  if (status.rejected) {
+    return 'rejected';
+  }
+
+  if (status.phase === 'saving_recipe') {
+    return 'saving_to_book';
+  }
+
+  if (status.phase === 'retryable_add_failure') {
+    return 'retryable_add_failure';
+  }
+
+  if (status.phase === 'recipe_saved' || status.phase === 'adding_to_plan') {
+    return 'recipe_saved';
+  }
+
+  return 'pending';
+}
 
 function parseIsoDateAsLocal(isoDate: string): Date | null {
   // Avoid JS Date parsing quirks where "YYYY-MM-DD" is treated as UTC,
@@ -91,22 +119,18 @@ export function MealProposalBlock({ block }: MealProposalBlockProps) {
     block.is_leftover,
     block.is_eating_out,
   ]);
+  const proposalInstanceId = block.proposal_id;
 
   const [persistedStatus, setPersistedStatus] = useState(() =>
     getMealProposalStatus(proposalKey)
   );
 
   useEffect(() => {
+    invalidateMealProposalStatus(proposalKey, proposalInstanceId);
     const status = getMealProposalStatus(proposalKey);
     setPersistedStatus(status);
-    if (status.addedToPlan) {
-      setState('accepted');
-    } else if (status.rejected) {
-      setState('rejected');
-    } else if (status.savedToBook) {
-      setState('saved_to_book');
-    }
-  }, [proposalKey]);
+    setState(getProposalState(status));
+  }, [proposalInstanceId, proposalKey]);
 
   const newRecipeSourceUrl = block.new_recipe?.source_url ?? undefined;
 
@@ -123,7 +147,7 @@ export function MealProposalBlock({ block }: MealProposalBlockProps) {
         isEatingOut: block.is_eating_out || false,
         notes: block.notes ?? undefined,
       });
-      markMealProposalAddedToPlan(proposalKey);
+      markMealProposalAddedToPlan(proposalKey, { proposalInstanceId });
       setPersistedStatus((prev) => ({ ...prev, addedToPlan: true }));
       setState('accepted');
 
@@ -186,8 +210,8 @@ export function MealProposalBlock({ block }: MealProposalBlockProps) {
       return;
     }
 
-    if (persistedStatus.savedToBook) {
-      setState('saved_to_book');
+    if (persistedStatus.canRetryAdd) {
+      handleSaveToRecipeBook();
       return;
     }
 
@@ -212,7 +236,7 @@ export function MealProposalBlock({ block }: MealProposalBlockProps) {
         isEatingOut: block.is_eating_out || false,
         notes: block.notes ?? undefined,
       });
-      markMealProposalAddedToPlan(proposalKey);
+      markMealProposalAddedToPlan(proposalKey, { proposalInstanceId });
       setPersistedStatus((prev) => ({ ...prev, addedToPlan: true }));
       setState('accepted');
 
@@ -239,7 +263,7 @@ export function MealProposalBlock({ block }: MealProposalBlockProps) {
   };
 
   const handleReject = () => {
-    markMealProposalRejected(proposalKey);
+    markMealProposalRejected(proposalKey, { proposalInstanceId });
     setPersistedStatus((prev) => ({ ...prev, rejected: true }));
     setState('rejected');
   };
@@ -289,17 +313,47 @@ export function MealProposalBlock({ block }: MealProposalBlockProps) {
     );
   }
 
-  if (state === 'saved_to_book') {
+  if (state === 'recipe_saved') {
     return (
       <div className="my-2 rounded-lg border border-blue-200 bg-blue-50 p-4">
         <div className="flex items-center gap-2 text-blue-700">
           <BookOpen className="h-5 w-5" />
-          <span className="font-medium">Saved to your recipe book</span>
+          <span className="font-medium">Recipe saved to your recipe book</span>
         </div>
         <p className="mt-2 text-sm text-blue-600">
-          If you chose “Add to Meal Plan”, it should now appear on{' '}
+          Continue the assistant flow to finish adding it to {block.day_label}.
+        </p>
+        <button
+          onClick={handleSaveToRecipeBook}
+          className="mt-4 inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 font-medium text-white transition-colors hover:bg-blue-700"
+        >
+          <Calendar className="h-4 w-4" />
+          Continue to Meal Plan
+        </button>
+      </div>
+    );
+  }
+
+  if (state === 'retryable_add_failure') {
+    return (
+      <div className="my-2 rounded-lg border border-amber-300 bg-amber-50 p-4">
+        <div className="flex items-center gap-2 text-amber-800">
+          <Calendar className="h-5 w-5" />
+          <span className="font-medium">
+            Add to meal plan needs one more try
+          </span>
+        </div>
+        <p className="mt-2 text-sm text-amber-700">
+          The recipe was saved, but we could not finish adding it to{' '}
           {block.day_label}.
         </p>
+        <button
+          onClick={handleSaveToRecipeBook}
+          className="mt-4 inline-flex items-center gap-2 rounded-md bg-amber-600 px-4 py-2 font-medium text-white transition-colors hover:bg-amber-700"
+        >
+          <Calendar className="h-4 w-4" />
+          Retry Add to Meal Plan
+        </button>
       </div>
     );
   }
@@ -490,27 +544,27 @@ export function MealProposalBlock({ block }: MealProposalBlockProps) {
             <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
               <button
                 onClick={handleSaveToRecipeBook}
-                disabled={
-                  isLoading ||
-                  persistedStatus.savedToBook ||
-                  persistedStatus.addedToPlan
-                }
+                disabled={isLoading || persistedStatus.addedToPlan}
                 className="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400"
               >
                 <BookOpen className="h-4 w-4" />
-                {persistedStatus.savedToBook ? 'Saved' : 'Save to Recipe Book'}
+                {persistedStatus.canRetryAdd
+                  ? 'Continue Saved Recipe'
+                  : persistedStatus.savedToBook
+                    ? 'Saved'
+                    : 'Save to Recipe Book'}
               </button>
               <button
                 onClick={handleAddNewToMealPlan}
-                disabled={
-                  isLoading ||
-                  persistedStatus.savedToBook ||
-                  persistedStatus.addedToPlan
-                }
+                disabled={isLoading || persistedStatus.addedToPlan}
                 className="inline-flex items-center justify-center gap-2 rounded-md bg-green-600 px-4 py-2 font-medium text-white transition-colors hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-400"
               >
                 <Calendar className="h-4 w-4" />
-                {persistedStatus.addedToPlan ? 'Added' : 'Add to Meal Plan'}
+                {persistedStatus.addedToPlan
+                  ? 'Added'
+                  : persistedStatus.canRetryAdd
+                    ? 'Continue to Meal Plan'
+                    : 'Add to Meal Plan'}
               </button>
             </div>
             <button

--- a/apps/frontend/src/components/recipes/AddByUrlModal.tsx
+++ b/apps/frontend/src/components/recipes/AddByUrlModal.tsx
@@ -27,6 +27,14 @@ interface AddByUrlModalProps {
   prefillUrl?: string;
 }
 
+const ASSISTANT_RETURN_PARAM_KEYS = [
+  'proposalKey',
+  'returnToAssistant',
+  'chatConversationId',
+  'mealPlanDate',
+  'mealPlanDayLabel',
+] as const;
+
 export const AddByUrlModal: FC<AddByUrlModalProps> = ({
   isOpen,
   onClose,
@@ -48,6 +56,30 @@ export const AddByUrlModal: FC<AddByUrlModalProps> = ({
       setUrl(prefillUrl);
     }
   }, [isOpen, prefillUrl]);
+
+  const buildRedirectPath = (
+    targetPath: string,
+    extraParams?: Record<string, string>
+  ) => {
+    const redirectUrl = new URL(targetPath, window.location.origin);
+    const mergedParams = new URLSearchParams(redirectUrl.search);
+
+    for (const key of ASSISTANT_RETURN_PARAM_KEYS) {
+      const value = searchParams.get(key);
+      if (value) {
+        mergedParams.set(key, value);
+      }
+    }
+
+    if (extraParams) {
+      for (const [key, value] of Object.entries(extraParams)) {
+        mergedParams.set(key, value);
+      }
+    }
+
+    const nextSearch = mergedParams.toString();
+    return `${redirectUrl.pathname}${nextSearch ? `?${nextSearch}` : ''}${redirectUrl.hash}`;
+  };
 
   const handleClose = () => {
     // Cancel any ongoing stream
@@ -123,7 +155,7 @@ export const AddByUrlModal: FC<AddByUrlModalProps> = ({
                   }
                 );
               }
-              navigate(signedUrl);
+              navigate(buildRedirectPath(signedUrl));
             } else if (draftId) {
               // Streaming endpoint case - fetch draft and navigate to new recipe page
               try {
@@ -131,16 +163,7 @@ export const AddByUrlModal: FC<AddByUrlModalProps> = ({
                 // Set the draft in the store
                 const { setFormFromSuggestion } = useRecipeStore.getState();
                 setFormFromSuggestion(draft.payload);
-                // Navigate to new recipe page with AI flag, preserving meal plan params
-                const params = new URLSearchParams();
-                params.set('ai', '1');
-                // Preserve meal plan params if present
-                const mealPlanDate = searchParams.get('mealPlanDate');
-                const mealPlanDayLabel = searchParams.get('mealPlanDayLabel');
-                if (mealPlanDate) params.set('mealPlanDate', mealPlanDate);
-                if (mealPlanDayLabel)
-                  params.set('mealPlanDayLabel', mealPlanDayLabel);
-                navigate(`/recipes/new?${params.toString()}`);
+                navigate(buildRedirectPath('/recipes/new', { ai: '1' }));
                 if (!completed) {
                   completed = true;
                   emitProductTelemetryEvent(
@@ -237,7 +260,7 @@ export const AddByUrlModal: FC<AddByUrlModalProps> = ({
       }
 
       // Navigate to the signed URL
-      navigate(response.signed_url);
+      navigate(buildRedirectPath(response.signed_url));
       handleClose();
     } catch (err) {
       logger.error('POST extraction failed:', err);

--- a/apps/frontend/src/components/recipes/__tests__/AddByUrlModal.test.tsx
+++ b/apps/frontend/src/components/recipes/__tests__/AddByUrlModal.test.tsx
@@ -49,8 +49,13 @@ vi.mock('../../../api/endpoints/aiDrafts', () => ({
 import { AddByUrlModal } from '../AddByUrlModal';
 
 // Helper to render with router context
-const renderWithRouter = (ui: React.ReactElement) => {
-  return render(<MemoryRouter>{ui}</MemoryRouter>);
+const renderWithRouter = (
+  ui: React.ReactElement,
+  initialEntries: string[] = ['/']
+) => {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+  );
 };
 
 describe('AddByUrlModal', () => {
@@ -116,7 +121,9 @@ describe('AddByUrlModal', () => {
     // getDraftByIdOwner should return a draft-like payload
     mockGetDraft.mockResolvedValue({ payload: { title: 'AI Recipe' } });
 
-    renderWithRouter(<AddByUrlModal isOpen={true} onClose={onClose} />);
+    renderWithRouter(<AddByUrlModal isOpen={true} onClose={onClose} />, [
+      '/recipes/new?proposalKey=test-key&returnToAssistant=1&chatConversationId=chat-123&mealPlanDate=2026-01-25&mealPlanDayLabel=Saturday',
+    ]);
 
     await user.type(
       screen.getByLabelText(/Recipe URL/i),
@@ -141,7 +148,9 @@ describe('AddByUrlModal', () => {
           featureName: 'url_import',
         })
       );
-      expect(mockNavigate).toHaveBeenCalledWith('/recipes/new?ai=1');
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/recipes/new?proposalKey=test-key&returnToAssistant=1&chatConversationId=chat-123&mealPlanDate=2026-01-25&mealPlanDayLabel=Saturday&ai=1'
+      );
       expect(onClose).toHaveBeenCalled();
     });
   });
@@ -158,7 +167,9 @@ describe('AddByUrlModal', () => {
     // Fallback POST should return signed_url
     mockExtractPost.mockResolvedValue({ signed_url: '/signed/redirect' });
 
-    renderWithRouter(<AddByUrlModal isOpen={true} onClose={onClose} />);
+    renderWithRouter(<AddByUrlModal isOpen={true} onClose={onClose} />, [
+      '/recipes/new?proposalKey=test-key&returnToAssistant=1&chatConversationId=chat-123&mealPlanDate=2026-01-25&mealPlanDayLabel=Saturday',
+    ]);
 
     await user.type(
       screen.getByLabelText(/Recipe URL/i),
@@ -175,7 +186,9 @@ describe('AddByUrlModal', () => {
           featureName: 'url_import',
         })
       );
-      expect(mockNavigate).toHaveBeenCalledWith('/signed/redirect');
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/signed/redirect?proposalKey=test-key&returnToAssistant=1&chatConversationId=chat-123&mealPlanDate=2026-01-25&mealPlanDayLabel=Saturday'
+      );
       expect(onClose).toHaveBeenCalled();
     });
   });
@@ -199,7 +212,9 @@ describe('AddByUrlModal', () => {
       }
     );
 
-    renderWithRouter(<AddByUrlModal isOpen={true} onClose={onClose} />);
+    renderWithRouter(<AddByUrlModal isOpen={true} onClose={onClose} />, [
+      '/recipes/new?proposalKey=test-key&returnToAssistant=1&chatConversationId=chat-123&mealPlanDate=2026-01-25&mealPlanDayLabel=Saturday',
+    ]);
 
     await user.type(
       screen.getByLabelText(/Recipe URL/i),
@@ -209,7 +224,9 @@ describe('AddByUrlModal', () => {
     fireEvent.submit(form);
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/signed/stream-redirect');
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/signed/stream-redirect?proposalKey=test-key&returnToAssistant=1&chatConversationId=chat-123&mealPlanDate=2026-01-25&mealPlanDayLabel=Saturday'
+      );
       expect(onClose).toHaveBeenCalled();
     });
   });

--- a/apps/frontend/src/pages/RecipesNewPage.tsx
+++ b/apps/frontend/src/pages/RecipesNewPage.tsx
@@ -33,7 +33,9 @@ import {
   type RecipeDifficulty,
 } from '../types/Recipe';
 import {
+  getMealProposalInstanceId,
   markMealProposalAddedToPlan,
+  markMealProposalRetryableAddFailure,
   markMealProposalSavedToBook,
 } from '../utils/mealProposalStatus';
 import { saveRecipeOffline } from '../utils/offlineSync';
@@ -501,6 +503,9 @@ const RecipesNewPage: FC = () => {
       const isAssistantFlow = !!proposalKey || !!mealPlanDate;
       const isExistingDuplicate =
         !result && !!existingDuplicateRecipeId && isAssistantFlow;
+      const proposalInstanceId = proposalKey
+        ? getMealProposalInstanceId(proposalKey)
+        : undefined;
 
       if (result || isExistingDuplicate) {
         // Clear duplicate state before navigating to prevent the duplicate-details
@@ -513,11 +518,17 @@ const RecipesNewPage: FC = () => {
           searchParams.get('chatConversationId') ?? undefined;
         const returnToAssistant =
           searchParams.get('returnToAssistant') === '1' ? true : false;
-        if (proposalKey) {
-          markMealProposalSavedToBook(proposalKey);
-        }
-
         const mealPlanDayLabel = searchParams.get('mealPlanDayLabel');
+        const proposalReturnContext = proposalKey
+          ? {
+              proposalKey,
+              returnToAssistant:
+                searchParams.get('returnToAssistant') ?? undefined,
+              chatConversationId,
+              mealPlanDate: mealPlanDate ?? undefined,
+              mealPlanDayLabel: mealPlanDayLabel ?? undefined,
+            }
+          : undefined;
         let nextPath: string = '/recipes';
 
         if (mealPlanDate && createdRecipeId) {
@@ -540,7 +551,11 @@ const RecipesNewPage: FC = () => {
               recipeId: createdRecipeId,
             });
             if (proposalKey) {
-              markMealProposalAddedToPlan(proposalKey);
+              markMealProposalAddedToPlan(proposalKey, {
+                proposalInstanceId,
+                recipeId: createdRecipeId,
+                returnContext: proposalReturnContext,
+              });
               useChatStore
                 .getState()
                 .appendLocalAssistantMessage(
@@ -560,15 +575,39 @@ const RecipesNewPage: FC = () => {
             }
           } catch (mealPlanErr) {
             logger.error('Failed to add recipe to meal plan:', mealPlanErr);
+            if (proposalKey) {
+              markMealProposalRetryableAddFailure(proposalKey, {
+                proposalInstanceId,
+                recipeId: createdRecipeId,
+                returnContext: proposalReturnContext,
+                lastError: 'meal_entry_create_failed',
+              });
+              useChatStore
+                .getState()
+                .appendLocalAssistantMessage(
+                  `I saved the recipe, but I couldn't add it to ${mealPlanDayLabel || mealPlanDate}. You can retry from the proposal card.`,
+                  chatConversationId
+                );
+            }
             success(
               isExistingDuplicate
-                ? 'Recipe already exists! However, we could not add it to your meal plan. You can add it manually from the Meal Plan page.'
-                : 'Recipe created! However, we could not add it to your meal plan. You can add it manually from the Meal Plan page.'
+                ? 'Recipe already exists! However, we could not add it to your meal plan. You can retry from the assistant or add it manually from the Meal Plan page.'
+                : 'Recipe created! However, we could not add it to your meal plan. You can retry from the assistant or add it manually from the Meal Plan page.'
             );
+
+            if (returnToAssistant && chatConversationId) {
+              info('Returning you to chat…');
+              nextPath = `/assistant?conversationId=${encodeURIComponent(chatConversationId)}`;
+            }
           }
         } else {
           // No meal plan date — just save the recipe.
           if (proposalKey) {
+            markMealProposalSavedToBook(proposalKey, {
+              proposalInstanceId,
+              recipeId: createdRecipeId,
+              returnContext: proposalReturnContext,
+            });
             useChatStore
               .getState()
               .appendLocalAssistantMessage(

--- a/apps/frontend/src/pages/__tests__/RecipesNewPage.test.tsx
+++ b/apps/frontend/src/pages/__tests__/RecipesNewPage.test.tsx
@@ -324,4 +324,119 @@ describe('RecipesNewPage - duplicate recipe handling', () => {
     expect(createMealEntryMock).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
   });
+
+  it('marks retryable add failure when createMealEntry rejects in assistant flow', async () => {
+    const addRecipeMock = vi.fn().mockImplementation(async () => {
+      recipeStoreState.duplicateInfo = {
+        existing_recipe_id: 'existing-uuid-789',
+        similar_recipes: [],
+      };
+      return null;
+    });
+    createMealEntryMock.mockRejectedValue(new Error('Network error'));
+
+    vi.doMock('../../stores/useRecipeStore', () => {
+      const useRecipeStore: any = () => ({
+        addRecipe: addRecipeMock,
+        formSuggestion: null,
+        isAISuggestion: false,
+        clearFormSuggestion: vi.fn(),
+        duplicateInfo: null,
+        forceCreateRecipe: vi.fn(),
+        clearDuplicateState: vi.fn(),
+      });
+      useRecipeStore.getState = () => recipeStoreState;
+      return { useRecipeStore };
+    });
+    vi.doMock('../../api/endpoints/mealPlans', () => ({
+      createMealEntry: createMealEntryMock,
+    }));
+    vi.doMock('react-router-dom', () => ({
+      useNavigate: () => navigateMock,
+      useSearchParams: () => [
+        new URLSearchParams(
+          'proposalKey=test-key&mealPlanDate=2026-04-14&mealPlanDayLabel=Monday'
+        ),
+        vi.fn(),
+      ],
+    }));
+
+    const { default: Page } = await import('../RecipesNewPage');
+    render((<Page />) as any);
+
+    await userEvent.type(screen.getByLabelText(/Recipe Name/i), 'Test Recipe');
+    await userEvent.type(screen.getByLabelText(/Ingredient 1/i), 'Flour');
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /Step 1/i }),
+      'Mix everything'
+    );
+    await userEvent.click(screen.getByRole('button', { name: /save recipe/i }));
+
+    await waitFor(() => {
+      expect(createMealEntryMock).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(markMealProposalRetryableAddFailureMock).toHaveBeenCalledWith(
+        'test-key',
+        expect.objectContaining({
+          proposalInstanceId: 'test-key',
+          recipeId: 'existing-uuid-789',
+          lastError: 'meal_entry_create_failed',
+        })
+      );
+    });
+    expect(markMealProposalAddedToPlanMock).not.toHaveBeenCalled();
+  });
+
+  it('marks saved to book when no mealPlanDate in assistant flow', async () => {
+    const addRecipeMock = vi.fn().mockResolvedValue({ id: 'new-recipe-id' });
+
+    vi.doMock('../../stores/useRecipeStore', () => {
+      const useRecipeStore: any = () => ({
+        addRecipe: addRecipeMock,
+        formSuggestion: null,
+        isAISuggestion: false,
+        clearFormSuggestion: vi.fn(),
+        duplicateInfo: null,
+        forceCreateRecipe: vi.fn(),
+        clearDuplicateState: vi.fn(),
+      });
+      useRecipeStore.getState = () => recipeStoreState;
+      return { useRecipeStore };
+    });
+    vi.doMock('../../api/endpoints/mealPlans', () => ({
+      createMealEntry: createMealEntryMock,
+    }));
+    vi.doMock('react-router-dom', () => ({
+      useNavigate: () => navigateMock,
+      useSearchParams: () => [
+        new URLSearchParams('proposalKey=test-key'),
+        vi.fn(),
+      ],
+    }));
+
+    const { default: Page } = await import('../RecipesNewPage');
+    render((<Page />) as any);
+
+    await userEvent.type(screen.getByLabelText(/Recipe Name/i), 'Test Recipe');
+    await userEvent.type(screen.getByLabelText(/Ingredient 1/i), 'Flour');
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /Step 1/i }),
+      'Mix everything'
+    );
+    await userEvent.click(screen.getByRole('button', { name: /save recipe/i }));
+
+    await waitFor(() => {
+      expect(markMealProposalSavedToBookMock).toHaveBeenCalledWith(
+        'test-key',
+        expect.objectContaining({
+          proposalInstanceId: 'test-key',
+          recipeId: 'new-recipe-id',
+        })
+      );
+    });
+    expect(createMealEntryMock).not.toHaveBeenCalled();
+    expect(markMealProposalAddedToPlanMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/frontend/src/pages/__tests__/RecipesNewPage.test.tsx
+++ b/apps/frontend/src/pages/__tests__/RecipesNewPage.test.tsx
@@ -8,6 +8,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const createMealEntryMock = vi.hoisted(() => vi.fn());
 const navigateMock = vi.hoisted(() => vi.fn());
 const clearDuplicateMock = vi.hoisted(() => vi.fn());
+const getMealProposalInstanceIdMock = vi.hoisted(() => vi.fn());
+const markMealProposalSavedToBookMock = vi.hoisted(() => vi.fn());
+const markMealProposalAddedToPlanMock = vi.hoisted(() => vi.fn());
+const markMealProposalRetryableAddFailureMock = vi.hoisted(() => vi.fn());
 
 // Mutable state shared between the hook mock and getState() so addRecipe can
 // simulate setting duplicateInfo (as the real Zustand store does on 409).
@@ -59,8 +63,10 @@ vi.mock('../../stores/useChatStore', () => ({
   }),
 }));
 vi.mock('../../utils/mealProposalStatus', () => ({
-  markMealProposalSavedToBook: vi.fn(),
-  markMealProposalAddedToPlan: vi.fn(),
+  getMealProposalInstanceId: getMealProposalInstanceIdMock,
+  markMealProposalSavedToBook: markMealProposalSavedToBookMock,
+  markMealProposalAddedToPlan: markMealProposalAddedToPlanMock,
+  markMealProposalRetryableAddFailure: markMealProposalRetryableAddFailureMock,
 }));
 vi.mock('../../api/endpoints/recipes', () => ({
   getRecipeById: vi.fn().mockResolvedValue(null),
@@ -174,6 +180,13 @@ describe('RecipesNewPage - duplicate recipe handling', () => {
     clearDuplicateMock.mockReset();
     createMealEntryMock.mockReset();
     createMealEntryMock.mockResolvedValue({ id: 'meal-1' });
+    getMealProposalInstanceIdMock.mockReset();
+    getMealProposalInstanceIdMock.mockImplementation(
+      (proposalKey: string) => proposalKey
+    );
+    markMealProposalSavedToBookMock.mockReset();
+    markMealProposalAddedToPlanMock.mockReset();
+    markMealProposalRetryableAddFailureMock.mockReset();
     recipeStoreState.duplicateInfo = null;
     try {
       window.localStorage.clear();
@@ -241,6 +254,19 @@ describe('RecipesNewPage - duplicate recipe handling', () => {
         })
       );
     });
+    expect(markMealProposalSavedToBookMock).not.toHaveBeenCalled();
+    expect(markMealProposalAddedToPlanMock).toHaveBeenCalledWith(
+      'test-key',
+      expect.objectContaining({
+        proposalInstanceId: 'test-key',
+        recipeId: 'existing-uuid-123',
+        returnContext: expect.objectContaining({
+          proposalKey: 'test-key',
+          mealPlanDate: '2026-04-14',
+        }),
+      })
+    );
+    expect(markMealProposalRetryableAddFailureMock).not.toHaveBeenCalled();
     expect(navigateMock).toHaveBeenCalled();
     // Duplicate modal should not be shown (auto-proceed path taken)
     expect(screen.queryByRole('dialog')).toBeNull();

--- a/apps/frontend/src/stores/useChatStore.ts
+++ b/apps/frontend/src/stores/useChatStore.ts
@@ -422,6 +422,7 @@ export const useChatStore = create<ChatState>()(
 
         // Accumulated text for building TextBlock
         let accumulatedText = '';
+        let serverMessageId: string | undefined;
         const finalizeStreamingState = (options?: {
           errorDetail?: string;
           clearError?: boolean;
@@ -430,7 +431,7 @@ export const useChatStore = create<ChatState>()(
           set((state) => {
             const messages =
               state.messagesByConversationId[conversationId] ?? [];
-            const targetMessageId = options?.messageId;
+            const targetMessageId = options?.messageId ?? serverMessageId;
             const updatedMessages = messages.map((message) => {
               if (
                 message.id === assistantMessageId ||
@@ -517,6 +518,9 @@ export const useChatStore = create<ChatState>()(
           {
             onDelta: (delta, messageId) => {
               accumulatedText += delta;
+              if (messageId && !serverMessageId) {
+                serverMessageId = messageId;
+              }
               set((state) => {
                 const messages =
                   state.messagesByConversationId[conversationId] ?? [];
@@ -550,6 +554,9 @@ export const useChatStore = create<ChatState>()(
             },
 
             onBlocksAppend: (blocks, messageId) => {
+              if (messageId && !serverMessageId) {
+                serverMessageId = messageId;
+              }
               set((state) => {
                 const messages =
                   state.messagesByConversationId[conversationId] ?? [];

--- a/apps/frontend/src/stores/useChatStore.ts
+++ b/apps/frontend/src/stores/useChatStore.ts
@@ -422,6 +422,62 @@ export const useChatStore = create<ChatState>()(
 
         // Accumulated text for building TextBlock
         let accumulatedText = '';
+        const finalizeStreamingState = (options?: {
+          errorDetail?: string;
+          clearError?: boolean;
+          messageId?: string;
+        }) => {
+          set((state) => {
+            const messages =
+              state.messagesByConversationId[conversationId] ?? [];
+            const targetMessageId = options?.messageId;
+            const updatedMessages = messages.map((message) => {
+              if (
+                message.id === assistantMessageId ||
+                (targetMessageId && message.id === targetMessageId)
+              ) {
+                const hasContent =
+                  (message.blocks && message.blocks.length > 0) ||
+                  accumulatedText.length > 0;
+
+                if (options?.errorDetail && !hasContent) {
+                  const errorBlock: ChatContentBlock = {
+                    type: 'text',
+                    text: `Sorry, I encountered an error: ${options.errorDetail}`,
+                  };
+                  return {
+                    ...message,
+                    blocks: [errorBlock],
+                    isStreaming: false,
+                    statusText: undefined,
+                  };
+                }
+
+                return {
+                  ...message,
+                  isStreaming: false,
+                  statusText: undefined,
+                };
+              }
+
+              return message;
+            });
+
+            return {
+              isLoading: false,
+              isStreaming: false,
+              streamingMessageId: null,
+              _abortController: null,
+              error:
+                options?.errorDetail ??
+                (options?.clearError ? null : state.error),
+              messagesByConversationId: {
+                ...state.messagesByConversationId,
+                [conversationId]: updatedMessages,
+              },
+            };
+          });
+        };
 
         // Create and expose the AbortController before streaming begins so
         // cancelPendingAssistantReply() can abort the in-flight request.
@@ -574,42 +630,7 @@ export const useChatStore = create<ChatState>()(
                   }
                 );
               }
-              set((state) => {
-                const messages =
-                  state.messagesByConversationId[conversationId] ?? [];
-                const updatedMessages = messages.map((m) => {
-                  if (m.id === assistantMessageId) {
-                    // Keep partial content if any, mark as not streaming
-                    const hasContent =
-                      (m.blocks && m.blocks.length > 0) ||
-                      accumulatedText.length > 0;
-                    if (!hasContent) {
-                      // Add error block
-                      const errorBlock: ChatContentBlock = {
-                        type: 'text',
-                        text: `Sorry, I encountered an error: ${detail}`,
-                      };
-                      return {
-                        ...m,
-                        blocks: [errorBlock],
-                        isStreaming: false,
-                      };
-                    }
-                    return { ...m, isStreaming: false };
-                  }
-                  return m;
-                });
-                return {
-                  isLoading: false,
-                  isStreaming: false,
-                  streamingMessageId: null,
-                  error: detail,
-                  messagesByConversationId: {
-                    ...state.messagesByConversationId,
-                    [conversationId]: updatedMessages,
-                  },
-                };
-              });
+              finalizeStreamingState({ errorDetail: detail });
             },
 
             onDone: () => {
@@ -627,12 +648,7 @@ export const useChatStore = create<ChatState>()(
                   }
                 );
               }
-              set({
-                isLoading: false,
-                isStreaming: false,
-                streamingMessageId: null,
-                _abortController: null,
-              });
+              finalizeStreamingState({ clearError: true });
             },
 
             onStatus: (status, detail) => {
@@ -731,6 +747,30 @@ export const useChatStore = create<ChatState>()(
           requestTelemetry,
           storeAbortController.signal
         );
+
+        if (!streamCompleted && !streamErrored) {
+          if (streamCancelled) {
+            finalizeStreamingState({ clearError: true });
+          } else {
+            streamErrored = true;
+            emitProductTelemetryEvent(
+              'assistant_message_failed',
+              requestTelemetry,
+              {
+                success: false,
+                streamed: true,
+                latency_ms: getTelemetryLatencyMs(streamStartedAt),
+                error_type: 'stream_terminated',
+                tool_count: startedToolNames.length,
+                tool_names: startedToolNames.slice(0, 10),
+              }
+            );
+            finalizeStreamingState({
+              errorDetail:
+                'The assistant connection closed unexpectedly. Please try again.',
+            });
+          }
+        }
       },
 
       cancelPendingAssistantReply: () => {

--- a/apps/frontend/src/types/Chat.ts
+++ b/apps/frontend/src/types/Chat.ts
@@ -82,7 +82,7 @@ export interface NewRecipeOption {
  */
 export interface MealProposalBlock {
   type: 'meal_proposal';
-  proposal_id: string; // For tracking accept/reject (e.g., "2026-01-26-proposal")
+  proposal_id: string; // Instance-scoped identifier (e.g., "2026-01-26-proposal-<uuid>")
   date: string; // ISO date (YYYY-MM-DD)
   day_label: string; // Human-friendly day name ("Monday", "Taco Tuesday", etc.)
   existing_recipe?: ExistingRecipeOption | null;

--- a/apps/frontend/src/utils/__tests__/mealProposalStatus.test.ts
+++ b/apps/frontend/src/utils/__tests__/mealProposalStatus.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  getMealProposalInstanceId,
   getMealProposalStatus,
+  invalidateMealProposalStatus,
   markMealProposalAddedToPlan,
   markMealProposalRejected,
   markMealProposalSavedToBook,
@@ -15,43 +17,65 @@ describe('mealProposalStatus', () => {
     it('returns all false for unknown proposal', () => {
       const status = getMealProposalStatus('unknown-proposal');
       expect(status).toEqual({
+        version: 1,
+        phase: 'pending',
+        updatedAt: undefined,
+        proposalInstanceId: undefined,
+        recipeId: undefined,
+        returnContext: undefined,
+        lastError: undefined,
         savedToBook: false,
         addedToPlan: false,
         rejected: false,
+        canRetryAdd: false,
       });
     });
 
     it('returns correct status after marking savedToBook', () => {
-      markMealProposalSavedToBook('test-proposal');
+      markMealProposalSavedToBook('test-proposal', {
+        proposalInstanceId: 'proposal-1',
+      });
       const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('recipe_saved');
+      expect(status.proposalInstanceId).toBe('proposal-1');
       expect(status.savedToBook).toBe(true);
       expect(status.addedToPlan).toBe(false);
       expect(status.rejected).toBe(false);
+      expect(status.canRetryAdd).toBe(true);
     });
 
     it('returns correct status after marking addedToPlan', () => {
-      markMealProposalAddedToPlan('test-proposal');
+      markMealProposalAddedToPlan('test-proposal', {
+        proposalInstanceId: 'proposal-2',
+      });
       const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('added_to_plan');
+      expect(status.proposalInstanceId).toBe('proposal-2');
       expect(status.savedToBook).toBe(false);
       expect(status.addedToPlan).toBe(true);
       expect(status.rejected).toBe(false);
+      expect(status.canRetryAdd).toBe(false);
     });
 
     it('returns correct status after marking rejected', () => {
       markMealProposalRejected('test-proposal');
       const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('rejected');
       expect(status.savedToBook).toBe(false);
       expect(status.addedToPlan).toBe(false);
       expect(status.rejected).toBe(true);
+      expect(status.canRetryAdd).toBe(false);
     });
 
     it('handles multiple flags being set', () => {
       markMealProposalSavedToBook('test-proposal');
       markMealProposalAddedToPlan('test-proposal');
       const status = getMealProposalStatus('test-proposal');
-      expect(status.savedToBook).toBe(true);
+      expect(status.phase).toBe('added_to_plan');
+      expect(status.savedToBook).toBe(false);
       expect(status.addedToPlan).toBe(true);
       expect(status.rejected).toBe(false);
+      expect(status.canRetryAdd).toBe(false);
     });
 
     it('handles different proposals independently', () => {
@@ -71,6 +95,22 @@ describe('mealProposalStatus', () => {
   });
 
   describe('error handling', () => {
+    it('extracts the proposal instance from the persisted proposal key', () => {
+      expect(
+        getMealProposalInstanceId('proposal-123|url:https://example.com')
+      ).toBe('proposal-123');
+    });
+
+    it('clears stale persisted state when the proposal instance changes', () => {
+      markMealProposalSavedToBook('test-proposal', {
+        proposalInstanceId: 'proposal-1',
+      });
+
+      invalidateMealProposalStatus('test-proposal', 'proposal-2');
+
+      expect(getMealProposalStatus('test-proposal').phase).toBe('pending');
+    });
+
     it('returns false when localStorage throws on read', () => {
       const getItemSpy = vi
         .spyOn(Storage.prototype, 'getItem')
@@ -80,9 +120,17 @@ describe('mealProposalStatus', () => {
 
       const status = getMealProposalStatus('test-proposal');
       expect(status).toEqual({
+        version: 1,
+        phase: 'pending',
+        updatedAt: undefined,
+        proposalInstanceId: undefined,
+        recipeId: undefined,
+        returnContext: undefined,
+        lastError: undefined,
         savedToBook: false,
         addedToPlan: false,
         rejected: false,
+        canRetryAdd: false,
       });
 
       getItemSpy.mockRestore();

--- a/apps/frontend/src/utils/__tests__/mealProposalStatus.test.ts
+++ b/apps/frontend/src/utils/__tests__/mealProposalStatus.test.ts
@@ -5,7 +5,10 @@ import {
   invalidateMealProposalStatus,
   markMealProposalAddedToPlan,
   markMealProposalRejected,
+  markMealProposalRetryableAddFailure,
   markMealProposalSavedToBook,
+  resetMealProposalStatus,
+  setMealProposalStatus,
 } from '../mealProposalStatus';
 
 describe('mealProposalStatus', () => {
@@ -149,6 +152,185 @@ describe('mealProposalStatus', () => {
       expect(() => markMealProposalRejected('test-proposal')).not.toThrow();
 
       setItemSpy.mockRestore();
+    });
+
+    it('does not throw when localStorage throws on remove', () => {
+      markMealProposalSavedToBook('test-proposal');
+      const removeItemSpy = vi
+        .spyOn(Storage.prototype, 'removeItem')
+        .mockImplementation(() => {
+          throw new Error('Storage unavailable');
+        });
+
+      expect(() => resetMealProposalStatus('test-proposal')).not.toThrow();
+
+      removeItemSpy.mockRestore();
+    });
+  });
+
+  describe('retryable add failure', () => {
+    it('marks proposal as retryable_add_failure', () => {
+      markMealProposalRetryableAddFailure('test-proposal', {
+        proposalInstanceId: 'proposal-1',
+        recipeId: 'recipe-123',
+        lastError: 'meal_entry_create_failed',
+      });
+      const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('retryable_add_failure');
+      expect(status.proposalInstanceId).toBe('proposal-1');
+      expect(status.recipeId).toBe('recipe-123');
+      expect(status.lastError).toBe('meal_entry_create_failed');
+      expect(status.savedToBook).toBe(true);
+      expect(status.canRetryAdd).toBe(true);
+      expect(status.addedToPlan).toBe(false);
+    });
+
+    it('transitions from retryable_add_failure to added_to_plan', () => {
+      markMealProposalRetryableAddFailure('test-proposal', {
+        proposalInstanceId: 'proposal-1',
+        lastError: 'meal_entry_create_failed',
+      });
+      markMealProposalAddedToPlan('test-proposal', {
+        proposalInstanceId: 'proposal-1',
+      });
+      const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('added_to_plan');
+      expect(status.canRetryAdd).toBe(false);
+      expect(status.lastError).toBeUndefined();
+    });
+  });
+
+  describe('setMealProposalStatus', () => {
+    it('merges update with existing status', () => {
+      markMealProposalSavedToBook('test-proposal', {
+        proposalInstanceId: 'proposal-1',
+      });
+      setMealProposalStatus('test-proposal', {
+        phase: 'adding_to_plan',
+        proposalInstanceId: 'proposal-1',
+      });
+      const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('adding_to_plan');
+      expect(status.proposalInstanceId).toBe('proposal-1');
+    });
+
+    it('stores and retrieves returnContext', () => {
+      markMealProposalSavedToBook('test-proposal', {
+        proposalInstanceId: 'proposal-1',
+        returnContext: {
+          proposalKey: 'test-proposal',
+          chatConversationId: 'chat-1',
+          mealPlanDate: '2026-01-26',
+          mealPlanDayLabel: 'Monday',
+        },
+      });
+      const status = getMealProposalStatus('test-proposal');
+      expect(status.returnContext).toEqual({
+        proposalKey: 'test-proposal',
+        chatConversationId: 'chat-1',
+        mealPlanDate: '2026-01-26',
+        mealPlanDayLabel: 'Monday',
+      });
+    });
+  });
+
+  describe('resetMealProposalStatus', () => {
+    it('clears persisted status back to pending', () => {
+      markMealProposalAddedToPlan('test-proposal', {
+        proposalInstanceId: 'proposal-1',
+      });
+      resetMealProposalStatus('test-proposal');
+      const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('pending');
+      expect(status.addedToPlan).toBe(false);
+    });
+  });
+
+  describe('invalidateMealProposalStatus', () => {
+    it('does not clear status when instance matches', () => {
+      markMealProposalSavedToBook('test-proposal', {
+        proposalInstanceId: 'proposal-1',
+      });
+      invalidateMealProposalStatus('test-proposal', 'proposal-1');
+      const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('recipe_saved');
+    });
+
+    it('does not clear status when no persisted state exists', () => {
+      invalidateMealProposalStatus('test-proposal', 'proposal-1');
+      const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('pending');
+    });
+  });
+
+  describe('getMealProposalInstanceId', () => {
+    it('returns full key when no pipe separator present', () => {
+      expect(getMealProposalInstanceId('proposal-123')).toBe('proposal-123');
+    });
+  });
+
+  describe('legacy migration', () => {
+    it('migrates legacy savedToBook flag to recipe_saved phase', () => {
+      localStorage.setItem(
+        'pantrypilot_meal_proposal:test-proposal:savedToBook',
+        '1'
+      );
+      const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('recipe_saved');
+      expect(status.savedToBook).toBe(true);
+      // Legacy key should be cleaned up
+      expect(
+        localStorage.getItem(
+          'pantrypilot_meal_proposal:test-proposal:savedToBook'
+        )
+      ).toBeNull();
+    });
+
+    it('migrates legacy addedToPlan flag to added_to_plan phase', () => {
+      localStorage.setItem(
+        'pantrypilot_meal_proposal:test-proposal:addedToPlan',
+        '1'
+      );
+      const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('added_to_plan');
+      expect(status.addedToPlan).toBe(true);
+    });
+
+    it('migrates legacy rejected flag to rejected phase', () => {
+      localStorage.setItem(
+        'pantrypilot_meal_proposal:test-proposal:rejected',
+        '1'
+      );
+      const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('rejected');
+      expect(status.rejected).toBe(true);
+    });
+
+    it('resets corrupted persisted status', () => {
+      localStorage.setItem(
+        'pantrypilot_meal_proposal:test-proposal:status',
+        JSON.stringify({ version: 1, phase: 'invalid_phase' })
+      );
+      const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('pending');
+    });
+
+    it('resets persisted status with wrong version', () => {
+      localStorage.setItem(
+        'pantrypilot_meal_proposal:test-proposal:status',
+        JSON.stringify({ version: 99, phase: 'pending' })
+      );
+      const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('pending');
+    });
+
+    it('resets unparseable JSON in storage', () => {
+      localStorage.setItem(
+        'pantrypilot_meal_proposal:test-proposal:status',
+        'not-json-at-all'
+      );
+      const status = getMealProposalStatus('test-proposal');
+      expect(status.phase).toBe('pending');
     });
   });
 });

--- a/apps/frontend/src/utils/mealProposalStatus.ts
+++ b/apps/frontend/src/utils/mealProposalStatus.ts
@@ -208,7 +208,13 @@ function toStatusView(
     persistedStatus.phase === 'retryable_add_failure';
 
   return {
-    ...persistedStatus,
+    version: persistedStatus.version,
+    phase: persistedStatus.phase,
+    updatedAt: persistedStatus.updatedAt,
+    proposalInstanceId: persistedStatus.proposalInstanceId,
+    recipeId: persistedStatus.recipeId,
+    returnContext: persistedStatus.returnContext,
+    lastError: persistedStatus.lastError,
     savedToBook,
     addedToPlan: persistedStatus.phase === 'added_to_plan',
     rejected: persistedStatus.phase === 'rejected',

--- a/apps/frontend/src/utils/mealProposalStatus.ts
+++ b/apps/frontend/src/utils/mealProposalStatus.ts
@@ -1,60 +1,318 @@
-export type MealProposalStatus = {
+export type MealProposalPhase =
+  | 'pending'
+  | 'saving_recipe'
+  | 'recipe_saved'
+  | 'adding_to_plan'
+  | 'retryable_add_failure'
+  | 'added_to_plan'
+  | 'rejected';
+
+export type MealProposalReturnContext = {
+  proposalKey?: string;
+  returnToAssistant?: string;
+  chatConversationId?: string;
+  mealPlanDate?: string;
+  mealPlanDayLabel?: string;
+};
+
+type PersistedMealProposalStatus = {
+  version: 1;
+  phase: MealProposalPhase;
+  updatedAt?: string;
+  proposalInstanceId?: string;
+  recipeId?: string;
+  returnContext?: MealProposalReturnContext;
+  lastError?: string;
+};
+
+export type MealProposalStatus = PersistedMealProposalStatus & {
   savedToBook: boolean;
   addedToPlan: boolean;
   rejected: boolean;
+  canRetryAdd: boolean;
 };
 
+export type MealProposalStatusUpdate = Omit<
+  PersistedMealProposalStatus,
+  'updatedAt' | 'version'
+>;
+
+export function getMealProposalInstanceId(proposalKey: string): string {
+  const [proposalInstanceId] = proposalKey.split('|');
+  return proposalInstanceId || proposalKey;
+}
+
 const KEY_PREFIX = 'pantrypilot_meal_proposal';
+const STATUS_KEY_SUFFIX = 'status';
+const STATUS_VERSION = 1 as const;
+const PHASES: ReadonlySet<MealProposalPhase> = new Set([
+  'pending',
+  'saving_recipe',
+  'recipe_saved',
+  'adding_to_plan',
+  'retryable_add_failure',
+  'added_to_plan',
+  'rejected',
+]);
+const LEGACY_STATUS_KEYS = ['savedToBook', 'addedToPlan', 'rejected'] as const;
 
-type MealProposalStatusKey = keyof MealProposalStatus;
+type LegacyMealProposalStatusKey = (typeof LEGACY_STATUS_KEYS)[number];
 
-function key(proposalKey: string, statusKey: MealProposalStatusKey): string {
+function statusStorageKey(proposalKey: string): string {
+  return `${KEY_PREFIX}:${proposalKey}:${STATUS_KEY_SUFFIX}`;
+}
+
+function legacyStorageKey(
+  proposalKey: string,
+  statusKey: LegacyMealProposalStatusKey
+): string {
   return `${KEY_PREFIX}:${proposalKey}:${statusKey}`;
 }
 
-function readFlag(
-  proposalKey: string,
-  statusKey: MealProposalStatusKey
-): boolean {
+function readStorageItem(storageKey: string): string | null {
   try {
-    return localStorage.getItem(key(proposalKey, statusKey)) === '1';
+    return localStorage.getItem(storageKey);
   } catch {
-    return false;
+    return null;
   }
 }
 
-function writeFlag(
-  proposalKey: string,
-  statusKey: MealProposalStatusKey,
-  value: boolean
-): void {
+function writeStorageItem(storageKey: string, value: string): void {
   try {
-    if (value) {
-      localStorage.setItem(key(proposalKey, statusKey), '1');
-    } else {
-      localStorage.removeItem(key(proposalKey, statusKey));
-    }
+    localStorage.setItem(storageKey, value);
   } catch {
     // localStorage might be unavailable (privacy mode, etc.)
   }
 }
 
-export function getMealProposalStatus(proposalKey: string): MealProposalStatus {
+function removeStorageItem(storageKey: string): void {
+  try {
+    localStorage.removeItem(storageKey);
+  } catch {
+    // localStorage might be unavailable (privacy mode, etc.)
+  }
+}
+
+function isMealProposalPhase(value: unknown): value is MealProposalPhase {
+  return typeof value === 'string' && PHASES.has(value as MealProposalPhase);
+}
+
+function readPersistedStatus(
+  proposalKey: string
+): PersistedMealProposalStatus | null {
+  const rawValue = readStorageItem(statusStorageKey(proposalKey));
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue = JSON.parse(
+      rawValue
+    ) as Partial<PersistedMealProposalStatus>;
+    if (
+      parsedValue.version !== STATUS_VERSION ||
+      !isMealProposalPhase(parsedValue.phase)
+    ) {
+      resetMealProposalStatus(proposalKey);
+      return null;
+    }
+
+    return {
+      version: STATUS_VERSION,
+      phase: parsedValue.phase,
+      updatedAt:
+        typeof parsedValue.updatedAt === 'string'
+          ? parsedValue.updatedAt
+          : undefined,
+      proposalInstanceId:
+        typeof parsedValue.proposalInstanceId === 'string'
+          ? parsedValue.proposalInstanceId
+          : undefined,
+      recipeId:
+        typeof parsedValue.recipeId === 'string'
+          ? parsedValue.recipeId
+          : undefined,
+      returnContext:
+        parsedValue.returnContext &&
+        typeof parsedValue.returnContext === 'object'
+          ? parsedValue.returnContext
+          : undefined,
+      lastError:
+        typeof parsedValue.lastError === 'string'
+          ? parsedValue.lastError
+          : undefined,
+    };
+  } catch {
+    resetMealProposalStatus(proposalKey);
+    return null;
+  }
+}
+
+function readLegacyFlag(
+  proposalKey: string,
+  statusKey: LegacyMealProposalStatusKey
+): boolean {
+  return readStorageItem(legacyStorageKey(proposalKey, statusKey)) === '1';
+}
+
+function clearLegacyStatus(proposalKey: string): void {
+  for (const legacyStatusKey of LEGACY_STATUS_KEYS) {
+    removeStorageItem(legacyStorageKey(proposalKey, legacyStatusKey));
+  }
+}
+
+function migrateLegacyStatus(
+  proposalKey: string
+): PersistedMealProposalStatus | null {
+  const savedToBook = readLegacyFlag(proposalKey, 'savedToBook');
+  const addedToPlan = readLegacyFlag(proposalKey, 'addedToPlan');
+  const rejected = readLegacyFlag(proposalKey, 'rejected');
+
+  if (!savedToBook && !addedToPlan && !rejected) {
+    return null;
+  }
+
+  const phase: MealProposalPhase = rejected
+    ? 'rejected'
+    : addedToPlan
+      ? 'added_to_plan'
+      : savedToBook
+        ? 'recipe_saved'
+        : 'pending';
+
+  const nextStatus: PersistedMealProposalStatus = {
+    version: STATUS_VERSION,
+    phase,
+    updatedAt: new Date().toISOString(),
+  };
+
+  persistStatus(proposalKey, nextStatus);
+
+  return nextStatus;
+}
+
+function persistStatus(
+  proposalKey: string,
+  status: PersistedMealProposalStatus
+): void {
+  writeStorageItem(statusStorageKey(proposalKey), JSON.stringify(status));
+  clearLegacyStatus(proposalKey);
+}
+
+function toStatusView(
+  persistedStatus: PersistedMealProposalStatus
+): MealProposalStatus {
+  const savedToBook =
+    persistedStatus.phase === 'recipe_saved' ||
+    persistedStatus.phase === 'adding_to_plan' ||
+    persistedStatus.phase === 'retryable_add_failure';
+
   return {
-    savedToBook: readFlag(proposalKey, 'savedToBook'),
-    addedToPlan: readFlag(proposalKey, 'addedToPlan'),
-    rejected: readFlag(proposalKey, 'rejected'),
+    ...persistedStatus,
+    savedToBook,
+    addedToPlan: persistedStatus.phase === 'added_to_plan',
+    rejected: persistedStatus.phase === 'rejected',
+    canRetryAdd:
+      persistedStatus.phase === 'recipe_saved' ||
+      persistedStatus.phase === 'retryable_add_failure',
   };
 }
 
-export function markMealProposalSavedToBook(proposalKey: string): void {
-  writeFlag(proposalKey, 'savedToBook', true);
+function getStoredMealProposalStatus(
+  proposalKey: string
+): PersistedMealProposalStatus {
+  return (
+    readPersistedStatus(proposalKey) ??
+    migrateLegacyStatus(proposalKey) ?? {
+      version: STATUS_VERSION,
+      phase: 'pending',
+    }
+  );
 }
 
-export function markMealProposalAddedToPlan(proposalKey: string): void {
-  writeFlag(proposalKey, 'addedToPlan', true);
+export function getMealProposalStatus(proposalKey: string): MealProposalStatus {
+  return toStatusView(getStoredMealProposalStatus(proposalKey));
 }
 
-export function markMealProposalRejected(proposalKey: string): void {
-  writeFlag(proposalKey, 'rejected', true);
+export function setMealProposalStatus(
+  proposalKey: string,
+  update: MealProposalStatusUpdate
+): void {
+  const currentStatus = getStoredMealProposalStatus(proposalKey);
+  const nextStatus: PersistedMealProposalStatus = {
+    ...currentStatus,
+    ...update,
+    version: STATUS_VERSION,
+    updatedAt: new Date().toISOString(),
+  };
+
+  if (
+    update.phase !== 'retryable_add_failure' &&
+    update.lastError === undefined
+  ) {
+    delete nextStatus.lastError;
+  }
+
+  persistStatus(proposalKey, nextStatus);
+}
+
+export function markMealProposalSavedToBook(
+  proposalKey: string,
+  context?: Omit<MealProposalStatusUpdate, 'phase'>
+): void {
+  setMealProposalStatus(proposalKey, {
+    ...context,
+    phase: 'recipe_saved',
+  });
+}
+
+export function markMealProposalAddedToPlan(
+  proposalKey: string,
+  context?: Omit<MealProposalStatusUpdate, 'phase'>
+): void {
+  setMealProposalStatus(proposalKey, {
+    ...context,
+    phase: 'added_to_plan',
+  });
+}
+
+export function markMealProposalRetryableAddFailure(
+  proposalKey: string,
+  context?: Omit<MealProposalStatusUpdate, 'phase'>
+): void {
+  setMealProposalStatus(proposalKey, {
+    ...context,
+    phase: 'retryable_add_failure',
+  });
+}
+
+export function markMealProposalRejected(
+  proposalKey: string,
+  context?: Omit<MealProposalStatusUpdate, 'phase'>
+): void {
+  setMealProposalStatus(proposalKey, {
+    ...context,
+    phase: 'rejected',
+  });
+}
+
+export function resetMealProposalStatus(proposalKey: string): void {
+  removeStorageItem(statusStorageKey(proposalKey));
+  clearLegacyStatus(proposalKey);
+}
+
+export function invalidateMealProposalStatus(
+  proposalKey: string,
+  proposalInstanceId: string
+): void {
+  const currentStatus = readPersistedStatus(proposalKey);
+  if (
+    !currentStatus ||
+    (currentStatus.proposalInstanceId &&
+      currentStatus.proposalInstanceId === proposalInstanceId)
+  ) {
+    return;
+  }
+
+  resetMealProposalStatus(proposalKey);
 }


### PR DESCRIPTION
## Summary
- replace boolean meal proposal persistence with a phase-based lifecycle and retryable recovery state
- preserve assistant return context across recipe extraction detours and strengthen proposal identity invalidation
- harden chat streaming cleanup for EOF or parse failure and normalize SSE terminal error handling

## Validation
- `npm exec vitest run src/utils/__tests__/mealProposalStatus.test.ts src/components/chat/__tests__/MealProposalBlock.test.tsx`
- `npm exec vitest run src/pages/__tests__/RecipesNewPage.test.tsx`
- `npm exec vitest run src/components/recipes/__tests__/AddByUrlModal.test.tsx`
- `npm exec vitest run src/api/endpoints/__tests__/chat.test.ts src/stores/__tests__/useChatStore.test.ts`
- `uv run pytest tests/services/test_meal_proposal_tool.py -q`
- `make ci`

Closes #497