### PR TITLE
Fix assistant DB session concurrency

### DIFF
--- a/apps/backend/src/services/chat_agent/deps.py
+++ b/apps/backend/src/services/chat_agent/deps.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from asyncio import Lock
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
 from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,3 +26,15 @@ class ChatAgentDeps:
     # User context for personalization
     user_preferences: UserPreferences | None = None
     memory_content: str | None = None
+    db_lock: Lock = field(default_factory=Lock, repr=False, compare=False)
+
+    @asynccontextmanager
+    async def use_db(self) -> AsyncIterator[AsyncSession]:
+        """Serialize access to the shared request-scoped async session.
+
+        Pydantic AI may execute multiple tool calls concurrently. SQLAlchemy
+        AsyncSession/asyncpg connections cannot process concurrent operations,
+        so assistant tools that use the injected session must acquire this guard.
+        """
+        async with self.db_lock:
+            yield self.db

--- a/apps/backend/src/services/chat_agent/tools/meal_history.py
+++ b/apps/backend/src/services/chat_agent/tools/meal_history.py
@@ -51,8 +51,9 @@ async def tool_get_meal_plan_history(
         .order_by(Meal.planned_for_date.desc(), Meal.meal_type)
     )
 
-    result = await ctx.deps.db.execute(stmt)
-    meals = result.scalars().all()
+    async with ctx.deps.use_db() as db:
+        result = await db.execute(stmt)
+        meals = result.scalars().all()
 
     # Count recipe frequencies for top recipes
     recipe_counts: dict[str, int] = {}

--- a/apps/backend/src/services/chat_agent/tools/recipes.py
+++ b/apps/backend/src/services/chat_agent/tools/recipes.py
@@ -215,9 +215,6 @@ async def _load_full_recipes(
 
     recipe_ids = list({r.id for r in recipes})
 
-    # Ensure any pending operations are complete before new query
-    await ctx.deps.db.flush()
-
     stmt = (
         select(Recipe)
         .where(Recipe.id.in_(recipe_ids))
@@ -227,8 +224,11 @@ async def _load_full_recipes(
             )
         )
     )
-    result = await ctx.deps.db.execute(stmt)
-    full_recipes = result.scalars().all()
+    async with ctx.deps.use_db() as db:
+        # Ensure any pending operations are complete before new query.
+        await db.flush()
+        result = await db.execute(stmt)
+        full_recipes = result.scalars().all()
     return {str(r.id): _recipe_to_full_payload(r) for r in full_recipes}
 
 
@@ -314,8 +314,9 @@ async def _hybrid_search_with_query(
         .limit(cte_limit)
     )
 
-    text_rows = (await ctx.deps.db.execute(text_stmt)).all()
-    vector_rows = (await ctx.deps.db.execute(vector_stmt)).all()
+    async with ctx.deps.use_db() as db:
+        text_rows = (await db.execute(text_stmt)).all()
+        vector_rows = (await db.execute(vector_stmt)).all()
 
     combined: dict[str, dict[str, Any]] = {}
 
@@ -570,8 +571,9 @@ async def tool_search_recipes(
     stmt = stmt.order_by(sort_map.get(sort_by, Recipe.name.asc()))
     stmt = stmt.limit(max_results)
 
-    result = await ctx.deps.db.execute(stmt)
-    rows = result.all()
+    async with ctx.deps.use_db() as db:
+        result = await db.execute(stmt)
+        rows = result.all()
 
     # If filters were applied but no rows returned, fall back to semantic search
     if filters and not rows:
@@ -672,8 +674,9 @@ async def tool_get_recipe_details(
         )
     )
 
-    result = await ctx.deps.db.execute(stmt)
-    recipe = result.scalar_one_or_none()
+    async with ctx.deps.use_db() as db:
+        result = await db.execute(stmt)
+        recipe = result.scalar_one_or_none()
     if recipe is None:
         return {
             "status": "not_found",

--- a/apps/backend/src/services/chat_agent/tools/weather.py
+++ b/apps/backend/src/services/chat_agent/tools/weather.py
@@ -14,4 +14,5 @@ async def tool_get_daily_weather(
     ctx: RunContext[ChatAgentDeps],
 ) -> dict[str, Any]:
     """Read-only weather lookup based on user profile."""
-    return await get_daily_forecast_for_user(ctx.deps.db, user_id=ctx.deps.user.id)
+    async with ctx.deps.use_db() as db:
+        return await get_daily_forecast_for_user(db, user_id=ctx.deps.user.id)

--- a/apps/backend/src/services/chat_agent/tools/weather.py
+++ b/apps/backend/src/services/chat_agent/tools/weather.py
@@ -6,8 +6,9 @@ from typing import Any
 
 from pydantic_ai import RunContext
 
+from crud.user_preferences import user_preferences_crud
 from services.chat_agent.deps import ChatAgentDeps
-from services.weather import get_daily_forecast_for_user
+from services.weather import get_daily_forecast_for_preferences
 
 
 async def tool_get_daily_weather(
@@ -15,4 +16,8 @@ async def tool_get_daily_weather(
 ) -> dict[str, Any]:
     """Read-only weather lookup based on user profile."""
     async with ctx.deps.use_db() as db:
-        return await get_daily_forecast_for_user(db, user_id=ctx.deps.user.id)
+        preferences = await user_preferences_crud.get_by_user_id(db, ctx.deps.user.id)
+    return await get_daily_forecast_for_preferences(
+        user_id=ctx.deps.user.id,
+        preferences=preferences,
+    )

--- a/apps/backend/src/services/weather.py
+++ b/apps/backend/src/services/weather.py
@@ -96,6 +96,18 @@ async def get_daily_forecast_for_user(
 ) -> dict[str, Any]:
     """Fetch daily forecast data for the user's saved location."""
     preferences = await user_preferences_crud.get_by_user_id(db, user_id)
+    return await get_daily_forecast_for_preferences(
+        user_id=user_id,
+        preferences=preferences,
+    )
+
+
+async def get_daily_forecast_for_preferences(
+    *,
+    user_id: UUID,
+    preferences: UserPreferences | None,
+) -> dict[str, Any]:
+    """Fetch daily forecast data for already-loaded user preferences."""
     if preferences is None:
         return {
             "status": "missing_location",

--- a/apps/backend/tests/services/test_chat_agent.py
+++ b/apps/backend/tests/services/test_chat_agent.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pydantic_ai import models
 from pydantic_ai.models.test import TestModel
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.user_preferences import UserPreferences
 from services.chat_agent import ChatAgentDeps, get_chat_agent
+from services.chat_agent.tools.recipes import tool_search_recipes
 
 
 # Block any real model requests in tests
@@ -25,6 +29,47 @@ class MockUser:
         self.id = "test-user-id"
         self.email = "test@example.com"
         self.full_name = "Test User"
+
+
+class MockRunContext:
+    """Minimal RunContext shape for direct tool tests."""
+
+    def __init__(self, deps: ChatAgentDeps) -> None:
+        self.deps = deps
+
+
+class EmptyResult:
+    """Minimal SQLAlchemy result shape returning no rows."""
+
+    def all(self) -> list[Any]:
+        return []
+
+
+class ConcurrencyCheckingSession:
+    """Fake async session that fails if execute calls overlap."""
+
+    def __init__(self) -> None:
+        self.active_execute_count = 0
+        self.max_active_execute_count = 0
+        self.execute_call_count = 0
+
+    async def execute(self, _statement: Any) -> EmptyResult:
+        self.execute_call_count += 1
+        self.active_execute_count += 1
+        self.max_active_execute_count = max(
+            self.max_active_execute_count,
+            self.active_execute_count,
+        )
+        try:
+            if self.active_execute_count > 1:
+                raise AssertionError("overlapping shared-session execute call")
+            await asyncio.sleep(0)
+            return EmptyResult()
+        finally:
+            self.active_execute_count -= 1
+
+    async def flush(self) -> None:
+        return None
 
 
 class TestChatAgentDeps:
@@ -63,6 +108,62 @@ class TestChatAgentDeps:
 
         assert deps.user_preferences == mock_prefs
         assert deps.memory_content == "User prefers spicy food"
+
+    @pytest.mark.asyncio
+    async def test_use_db_serializes_shared_session_access(self) -> None:
+        """Test shared assistant DB session access is serialized."""
+        db = AsyncMock()
+        deps = ChatAgentDeps(
+            db=db,
+            user=MockUser(),  # type: ignore
+            current_datetime=datetime.now(UTC),
+            user_timezone="UTC",
+        )
+
+        active_users = 0
+        max_active_users = 0
+        events: list[str] = []
+
+        async def use_shared_db(label: str) -> None:
+            nonlocal active_users, max_active_users
+            async with deps.use_db() as guarded_db:
+                assert guarded_db is db
+                active_users += 1
+                max_active_users = max(max_active_users, active_users)
+                events.append(f"{label}:start")
+                await asyncio.sleep(0)
+                events.append(f"{label}:end")
+                active_users -= 1
+
+        await asyncio.gather(use_shared_db("first"), use_shared_db("second"))
+
+        assert max_active_users == 1
+        assert events == ["first:start", "first:end", "second:start", "second:end"]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_recipe_search_serializes_shared_session(self) -> None:
+        """Test concurrent DB-backed recipe tools do not overlap session use."""
+        db = ConcurrencyCheckingSession()
+        deps = ChatAgentDeps(
+            db=cast(AsyncSession, db),
+            user=MockUser(),  # type: ignore
+            current_datetime=datetime.now(UTC),
+            user_timezone="UTC",
+        )
+        ctx = cast(Any, MockRunContext(deps))
+
+        with patch(
+            "services.chat_agent.tools.recipes.generate_query_embedding",
+            new_callable=AsyncMock,
+            return_value=[0.1, 0.2, 0.3],
+        ):
+            await asyncio.gather(
+                tool_search_recipes(ctx, query="chicken"),
+                tool_search_recipes(ctx, query="pasta"),
+            )
+
+        assert db.execute_call_count == 4
+        assert db.max_active_execute_count == 1
 
 
 class TestAgentConstruction:

--- a/apps/backend/tests/services/test_chat_agent.py
+++ b/apps/backend/tests/services/test_chat_agent.py
@@ -138,7 +138,8 @@ class TestChatAgentDeps:
         await asyncio.gather(use_shared_db("first"), use_shared_db("second"))
 
         assert max_active_users == 1
-        assert events == ["first:start", "first:end", "second:start", "second:end"]
+        assert len(events) == 4
+        assert set(events) == {"first:start", "first:end", "second:start", "second:end"}
 
     @pytest.mark.asyncio
     async def test_concurrent_recipe_search_serializes_shared_session(self) -> None:


### PR DESCRIPTION
## Summary

Fixes a production assistant failure where concurrent Pydantic AI tool calls could share the same SQLAlchemy `AsyncSession` and trigger asyncpg's `cannot perform operation: another operation is in progress` error.

## Changes

- Add a serialized `ChatAgentDeps.use_db()` accessor for request-scoped assistant DB sessions.
- Route DB-backed assistant tools through the guard for recipe search/details, meal history, and weather lookups.
- Add regression tests that run concurrent recipe searches against a fake session that fails on overlapping `execute()` calls.

## Validation

- `make ci` passed locally.
- Focused backend validation passed while developing: Ruff, mypy, and pytest for touched assistant files.