### PR TITLE
Add backend OpenTelemetry tracing validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,7 +88,7 @@ LOG_LEVEL=INFO
 SENTRY_DSN=
 
 # =============================================================================
-# OBSERVABILITY / TELEMETRY (Azure Monitor)
+# OBSERVABILITY / TELEMETRY (Azure Monitor / Local OpenTelemetry)
 # =============================================================================
 # Enable OpenTelemetry integration with Azure Monitor Application Insights.
 # Set to true in production with a valid connection string.
@@ -101,6 +101,13 @@ APPLICATIONINSIGHTS_CONNECTION_STRING=
 
 # OpenTelemetry service name for trace identification (default: pantrypilot-backend)
 OTEL_SERVICE_NAME=pantrypilot-backend
+
+# Optional local trace validation without Azure credentials.
+# Uncomment these with ENABLE_OBSERVABILITY=true to print spans to the backend console.
+# OTEL_SERVICE_NAME=pantrypilot-backend-dev
+# OTEL_TRACES_EXPORTER=console
+# OTEL_TRACES_SAMPLER=always_on
+# OTEL_PYTHON_LOG_CORRELATION=true
 
 # =============================================================================
 # SECURITY HEADERS (Production)

--- a/apps/backend/src/api/v1/chat.py
+++ b/apps/backend/src/api/v1/chat.py
@@ -36,6 +36,7 @@ from core.error_handler import get_correlation_id
 from core.observability import (
     ProductTelemetryEventName,
     build_product_telemetry_attributes,
+    get_current_span,
     get_tracer,
     record_product_telemetry_event,
 )
@@ -1036,6 +1037,30 @@ def _extract_interactive_blocks_from_tool_result(
     return blocks
 
 
+def _record_tool_lifecycle_event_on_current_span(
+    *,
+    event: ProductTelemetryEventName,
+    request_id: str,
+    conversation_id: UUID,
+    tool_name: str,
+    success: bool | None = None,
+    latency_ms: int | None = None,
+) -> None:
+    """Attach supplemental tool lifecycle metadata to the active assistant span."""
+    attrs = build_product_telemetry_attributes(
+        event=event,
+        feature_name="assistant",
+        request_id=request_id,
+        conversation_id=str(conversation_id),
+        success=success,
+        latency_ms=latency_ms,
+        tool_count=1,
+        tool_names=[tool_name],
+        streamed=True,
+    )
+    get_current_span().add_event(event.value, attributes=attrs)
+
+
 async def _handle_agent_stream_event(  # noqa: C901
     event: object,
     *,
@@ -1065,19 +1090,12 @@ async def _handle_agent_stream_event(  # noqa: C901
             started_at=datetime.now(UTC),
             call_order=current_order,
         )
-        with _tracer.start_as_current_span(f"tool_start:{tool_name}") as span:
-            for key, value in build_product_telemetry_attributes(
-                event=ProductTelemetryEventName.ASSISTANT_TOOL_STARTED,
-                feature_name="assistant",
-                request_id=request_id,
-                conversation_id=str(conversation_id),
-                tool_count=1,
-                tool_names=[tool_name],
-                streamed=True,
-            ).items():
-                span.set_attribute(key, value)
-            span.set_attribute("tool_call_id", event.tool_call_id)
-            span.set_attribute("call_order", current_order)
+        _record_tool_lifecycle_event_on_current_span(
+            event=ProductTelemetryEventName.ASSISTANT_TOOL_STARTED,
+            request_id=request_id,
+            conversation_id=conversation_id,
+            tool_name=tool_name,
+        )
         return (
             [
                 ChatSseEvent(
@@ -1100,31 +1118,17 @@ async def _handle_agent_stream_event(  # noqa: C901
         tool_name = tool_start.tool_name if tool_start else "unknown"
         arguments = tool_start.arguments if tool_start else {}
         started_at = tool_start.started_at if tool_start else datetime.now(UTC)
-        call_order = tool_start.call_order if tool_start else -1
         finished_at = datetime.now(UTC)
         duration_ms = (finished_at - started_at).total_seconds() * 1000
 
-        # Create tracing span for tool call
-        with _tracer.start_as_current_span(f"tool_call:{tool_name}") as span:
-            for key, value in build_product_telemetry_attributes(
-                event=ProductTelemetryEventName.ASSISTANT_TOOL_COMPLETED,
-                feature_name="assistant",
-                request_id=request_id,
-                conversation_id=str(conversation_id),
-                success=True,
-                latency_ms=int(duration_ms),
-                tool_count=1,
-                tool_names=[tool_name],
-                streamed=True,
-            ).items():
-                span.set_attribute(key, value)
-            span.set_attribute("tool_name", tool_name)
-            span.set_attribute("tool_call_id", event.tool_call_id)
-            span.set_attribute("call_order", call_order)
-            span.set_attribute("duration_ms", duration_ms)
-            span.set_attribute("conversation_id", str(conversation_id))
-            span.set_attribute("message_id", str(message_id))
-            span.set_attribute("status", "success")
+        _record_tool_lifecycle_event_on_current_span(
+            event=ProductTelemetryEventName.ASSISTANT_TOOL_COMPLETED,
+            request_id=request_id,
+            conversation_id=conversation_id,
+            tool_name=tool_name,
+            success=True,
+            latency_ms=int(duration_ms),
+        )
 
         result_content = getattr(event.result, "content", None)
         if isinstance(result_content, dict):

--- a/apps/backend/src/core/observability.py
+++ b/apps/backend/src/core/observability.py
@@ -26,6 +26,7 @@ For local development:
 - Logfire can be used as optional dev tooling for quick trace visualization
 - Do NOT rely on Logfire for production retention
 - Set ENABLE_OBSERVABILITY=false locally if traces are not needed
+- Set OTEL_TRACES_EXPORTER=console locally to print spans without Azure secrets
 
 For production (Azure):
 - Set APPLICATIONINSIGHTS_CONNECTION_STRING to your App Insights connection string
@@ -56,6 +57,7 @@ logger = logging.getLogger(__name__)
 _ENV_ENABLE_OBSERVABILITY = "ENABLE_OBSERVABILITY"
 _ENV_APP_INSIGHTS_CONN_STRING = "APPLICATIONINSIGHTS_CONNECTION_STRING"
 _ENV_OTEL_SERVICE_NAME = "OTEL_SERVICE_NAME"
+_ENV_OTEL_TRACES_EXPORTER = "OTEL_TRACES_EXPORTER"
 
 # Default service name for OpenTelemetry
 _DEFAULT_SERVICE_NAME = "pantrypilot-backend"
@@ -202,6 +204,15 @@ def _get_connection_string() -> str | None:
     return os.getenv(_ENV_APP_INSIGHTS_CONN_STRING)
 
 
+def _is_console_trace_exporter_enabled() -> bool:
+    """Return whether local console span export is requested."""
+    exporters = {
+        exporter.strip().lower()
+        for exporter in os.getenv(_ENV_OTEL_TRACES_EXPORTER, "").split(",")
+    }
+    return "console" in exporters
+
+
 def _get_installed_version(package_name: str) -> str:
     """Return installed package version for observability diagnostics."""
     try:
@@ -237,6 +248,20 @@ def _enable_pydantic_ai_instrumentation() -> None:
         )
 
 
+def _configure_console_trace_exporter(service_name: str) -> None:
+    """Configure local console trace export for development validation."""
+    from opentelemetry import trace
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+    provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
+    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+    trace.set_tracer_provider(provider)
+    FastAPIInstrumentor().instrument(excluded_urls=EXCLUDED_URLS)
+
+
 @lru_cache
 def configure_observability() -> bool:
     """Configure OpenTelemetry with Azure Monitor for production observability.
@@ -267,20 +292,47 @@ def configure_observability() -> bool:
         )
         return False
 
+    service_name = os.getenv(_ENV_OTEL_SERVICE_NAME, _DEFAULT_SERVICE_NAME)
     connection_string = _get_connection_string()
+
+    # Set excluded URLs for FastAPI instrumentation before either Azure Monitor
+    # or the local development exporter configures instrumentation.
+    os.environ.setdefault("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS", EXCLUDED_URLS)
+
+    if not connection_string and _is_console_trace_exporter_enabled():
+        try:
+            _configure_console_trace_exporter(service_name)
+            _enable_pydantic_ai_instrumentation()
+            logger.info(
+                "Console OpenTelemetry observability configured for service '%s'",
+                service_name,
+            )
+            return True
+        except ImportError as exc:
+            logger.warning(
+                "Failed to import OpenTelemetry console exporter dependencies: %s",
+                exc,
+            )
+            return False
+        except Exception as exc:
+            logger.exception(
+                "Failed to configure console OpenTelemetry observability: %s",
+                exc,
+            )
+            return False
+
     if not connection_string:
         logger.warning(
-            "Observability enabled but %s not set. Skipping Azure Monitor setup.",
+            "Observability enabled but %s not set and %s is not console. "
+            "Skipping OpenTelemetry setup.",
             _ENV_APP_INSIGHTS_CONN_STRING,
+            _ENV_OTEL_TRACES_EXPORTER,
         )
         return False
 
     try:
         # Import Azure Monitor OpenTelemetry only when needed
         from azure.monitor.opentelemetry import configure_azure_monitor
-
-        # Set service name for OpenTelemetry resource attributes
-        service_name = os.getenv(_ENV_OTEL_SERVICE_NAME, _DEFAULT_SERVICE_NAME)
 
         # Configure Azure Monitor with FastAPI instrumentation
         # Note: This must be called BEFORE importing FastAPI for proper instrumentation
@@ -291,9 +343,6 @@ def configure_observability() -> bool:
             # We set it here for documentation purposes; the actual exclusion
             # is handled by setting OTEL_PYTHON_FASTAPI_EXCLUDED_URLS env var
         )
-
-        # Set excluded URLs for FastAPI instrumentation
-        os.environ.setdefault("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS", EXCLUDED_URLS)
 
         _enable_pydantic_ai_instrumentation()
 

--- a/apps/backend/src/core/observability.py
+++ b/apps/backend/src/core/observability.py
@@ -377,6 +377,16 @@ def get_current_span() -> Any:
         return _NoOpSpan()
 
 
+def set_span_error_status(span: Any, exception: BaseException) -> None:
+    """Set OpenTelemetry error status with a low-cardinality description."""
+    try:
+        from opentelemetry.trace import Status, StatusCode
+
+        span.set_status(Status(StatusCode.ERROR, type(exception).__name__))
+    except ImportError:
+        logger.debug("OpenTelemetry not available; skipping span status")
+
+
 class _NoOpTracer:
     """A no-op tracer for when OpenTelemetry is not available."""
 
@@ -407,6 +417,9 @@ class _NoOpSpan:
 
     def record_exception(self, exception: BaseException) -> None:
         """No-op exception recorder."""
+
+    def set_status(self, status: object) -> None:
+        """No-op status setter."""
 
     def end(self) -> None:
         """No-op span end."""

--- a/apps/backend/src/core/observability.py
+++ b/apps/backend/src/core/observability.py
@@ -63,6 +63,8 @@ _DEFAULT_SERVICE_NAME = "pantrypilot-backend"
 # Paths to exclude from automatic tracing (reduce noise for health checks)
 EXCLUDED_URLS = "health,health/,favicon.ico"
 
+_pydantic_ai_instrumented = False
+
 
 class ProductTelemetryEventName(StrEnum):
     """Canonical backend product telemetry event names."""
@@ -208,6 +210,33 @@ def _get_installed_version(package_name: str) -> str:
         return "not-installed"
 
 
+def _enable_pydantic_ai_instrumentation() -> None:
+    """Enable Pydantic AI OpenTelemetry spans after provider setup."""
+    global _pydantic_ai_instrumented
+
+    if _pydantic_ai_instrumented:
+        logger.debug("Pydantic AI OpenTelemetry instrumentation already enabled")
+        return
+
+    try:
+        from pydantic_ai import Agent
+
+        Agent.instrument_all()
+        _pydantic_ai_instrumented = True
+        logger.info("Pydantic AI OpenTelemetry instrumentation enabled")
+    except ImportError as exc:
+        logger.warning(
+            "Pydantic AI instrumentation unavailable: %s. Installed version: %s",
+            exc,
+            _get_installed_version("pydantic-ai-slim"),
+        )
+    except Exception as exc:
+        logger.exception(
+            "Failed to enable Pydantic AI OpenTelemetry instrumentation: %s",
+            exc,
+        )
+
+
 @lru_cache
 def configure_observability() -> bool:
     """Configure OpenTelemetry with Azure Monitor for production observability.
@@ -265,6 +294,8 @@ def configure_observability() -> bool:
 
         # Set excluded URLs for FastAPI instrumentation
         os.environ.setdefault("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS", EXCLUDED_URLS)
+
+        _enable_pydantic_ai_instrumentation()
 
         logger.info(
             "Azure Monitor observability configured for service '%s'",

--- a/apps/backend/src/core/observability.py
+++ b/apps/backend/src/core/observability.py
@@ -366,6 +366,17 @@ def get_tracer(name: str) -> Any:
         return _NoOpTracer()
 
 
+def get_current_span() -> Any:
+    """Return the active OpenTelemetry span or a no-op span."""
+    try:
+        from opentelemetry import trace
+
+        return trace.get_current_span()
+    except ImportError:
+        logger.debug("OpenTelemetry not available; returning no-op current span")
+        return _NoOpSpan()
+
+
 class _NoOpTracer:
     """A no-op tracer for when OpenTelemetry is not available."""
 

--- a/apps/backend/src/services/ai/draft_service.py
+++ b/apps/backend/src/services/ai/draft_service.py
@@ -26,6 +26,7 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import crud.ai_drafts as crud_ai_drafts
+from core.observability import get_tracer, set_span_error_status
 from core.security import create_draft_token as core_create_draft_token
 from models.ai_drafts import AIDraft
 from models.users import User
@@ -33,6 +34,7 @@ from schemas.ai import ExtractionNotFound
 
 
 logger = logging.getLogger(__name__)
+_tracer = get_tracer(__name__)
 
 
 class _FailureDraftStub:
@@ -76,38 +78,56 @@ async def create_success_draft(
     Always uses `crud.ai_drafts.create_draft` (no api-level override probing).
     """
     payload = _normalize_payload(generated_recipe)
-    try:
-        draft_any = await _maybe_call(
-            crud_ai_drafts.create_draft,
-            db=db,
-            user_id=current_user.id,
+    with _tracer.start_as_current_span("recipe_draft.create") as span:
+        _set_draft_span_attributes(
+            span,
             draft_type="recipe_suggestion",
-            payload=payload,
             source_url=source_url,
-            prompt_used=prompt_override,
-            ttl_hours=1,
+            prompt_override=prompt_override,
+            payload=payload,
         )
-        draft = cast(AIDraft, draft_any)
-    except AttributeError as exc:  # pragma: no cover - defensive
-        from uuid import uuid4
+        try:
+            try:
+                draft_any = await _maybe_call(
+                    crud_ai_drafts.create_draft,
+                    db=db,
+                    user_id=current_user.id,
+                    draft_type="recipe_suggestion",
+                    payload=payload,
+                    source_url=source_url,
+                    prompt_used=prompt_override,
+                    ttl_hours=1,
+                )
+                draft = cast(AIDraft, draft_any)
+            except AttributeError as exc:  # pragma: no cover - defensive
+                from uuid import uuid4
 
-        logger.debug(
-            "create_success_draft: limited DB session, returning stub draft: %s",
-            exc,
-        )
-        draft = cast(
-            AIDraft,
-            _FailureDraftStub(
-                id=uuid4(),
-                payload=payload,
-                expires_at=datetime.now(UTC) + timedelta(hours=1),
-            ),
-        )
-    logger.debug(
-        "create_success_draft: created draft id=%s", getattr(draft, "id", None)
-    )
-    # mypy: ensure return type is AIDraft-like; tests may use Mock with same attrs
-    return draft
+                logger.debug(
+                    "create_success_draft: limited DB session, "
+                    "returning stub draft: %s",
+                    exc,
+                )
+                draft = cast(
+                    AIDraft,
+                    _FailureDraftStub(
+                        id=uuid4(),
+                        payload=payload,
+                        expires_at=datetime.now(UTC) + timedelta(hours=1),
+                    ),
+                )
+            span.set_attribute("recipe_draft.status", "created")
+            span.set_attribute(
+                "recipe_draft.id_present", getattr(draft, "id", None) is not None
+            )
+            logger.debug(
+                "create_success_draft: created draft id=%s", getattr(draft, "id", None)
+            )
+            return draft
+        except Exception as exc:
+            span.set_attribute("recipe_draft.status", "error")
+            span.record_exception(exc)
+            set_span_error_status(span, exc)
+            raise
 
 
 async def create_failure_draft(
@@ -128,39 +148,60 @@ async def create_failure_draft(
     except Exception:  # pragma: no cover - defensive
         payload["detail"] = str(extraction_not_found)
 
-    try:
-        draft_any = await _maybe_call(
-            crud_ai_drafts.create_draft,
-            db=db,
-            user_id=current_user.id,
+    with _tracer.start_as_current_span("recipe_draft.create") as span:
+        _set_draft_span_attributes(
+            span,
             draft_type="recipe_suggestion_failure",
-            payload=payload,
             source_url=source_url,
-            prompt_used=prompt_override,
-            ttl_hours=1,
+            prompt_override=prompt_override,
+            payload=payload,
         )
-        draft = cast(AIDraft, draft_any)
-    except AttributeError as exc:  # pragma: no cover - defensive
-        from uuid import uuid4
+        span.set_attribute("recipe_draft.failure", True)
+        try:
+            try:
+                draft_any = await _maybe_call(
+                    crud_ai_drafts.create_draft,
+                    db=db,
+                    user_id=current_user.id,
+                    draft_type="recipe_suggestion_failure",
+                    payload=payload,
+                    source_url=source_url,
+                    prompt_used=prompt_override,
+                    ttl_hours=1,
+                )
+                draft = cast(AIDraft, draft_any)
+            except AttributeError as exc:  # pragma: no cover - defensive
+                from uuid import uuid4
 
-        logger.debug(
-            "create_failure_draft: limited DB session, returning stub draft: %s",
-            exc,
-        )
-        draft = cast(
-            AIDraft,
-            _FailureDraftStub(
-                id=uuid4(),
-                payload=payload,
-                expires_at=datetime.now(UTC) + timedelta(hours=1),
-            ),
-        )
-    # Keep an expires_at attribute for tests; set to now+1h
-    draft.expires_at = datetime.now(UTC) + timedelta(hours=1)
-    logger.debug(
-        "create_failure_draft: created failure draft id=%s", getattr(draft, "id", None)
-    )
-    return draft
+                logger.debug(
+                    "create_failure_draft: limited DB session, "
+                    "returning stub draft: %s",
+                    exc,
+                )
+                draft = cast(
+                    AIDraft,
+                    _FailureDraftStub(
+                        id=uuid4(),
+                        payload=payload,
+                        expires_at=datetime.now(UTC) + timedelta(hours=1),
+                    ),
+                )
+            # Keep an expires_at attribute for tests; set to now+1h
+            draft.expires_at = datetime.now(UTC) + timedelta(hours=1)
+            span.set_attribute("recipe_draft.status", "created")
+            span.set_attribute(
+                "recipe_draft.id_present", getattr(draft, "id", None) is not None
+            )
+            logger.debug(
+                "create_failure_draft: created failure draft id=%s",
+                getattr(draft, "id", None),
+            )
+            return draft
+        except Exception as exc:
+            span.set_attribute("recipe_draft.status", "error")
+            span.record_exception(exc)
+            set_span_error_status(span, exc)
+            raise
 
 
 def create_draft_token(
@@ -190,3 +231,49 @@ def _normalize_payload(obj: Any) -> dict[str, Any]:
         return {"value": str(obj)}
     except Exception:
         return {"value": str(obj)}
+
+
+def _source_type(source_url: str) -> str:
+    if source_url == "image_upload":
+        return "image"
+    if source_url:
+        return "url"
+    return "unknown"
+
+
+def _recipe_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    recipe_data = payload.get("recipe_data")
+    if isinstance(recipe_data, dict):
+        return recipe_data
+    return payload
+
+
+def _count_items(value: object) -> int:
+    if isinstance(value, list | tuple):
+        return len(value)
+    return 0
+
+
+def _set_draft_span_attributes(
+    span: Any,
+    *,
+    draft_type: str,
+    source_url: str,
+    prompt_override: str | None,
+    payload: dict[str, Any],
+) -> None:
+    recipe_payload = _recipe_payload(payload)
+    source_type = _source_type(source_url)
+    span.set_attribute("recipe_draft.type", draft_type)
+    span.set_attribute("recipe_draft.source_type", source_type)
+    span.set_attribute("recipe_draft.has_source_url", source_type == "url")
+    span.set_attribute("recipe_draft.prompt_override_used", prompt_override is not None)
+    span.set_attribute("recipe_draft.has_title", bool(recipe_payload.get("title")))
+    span.set_attribute(
+        "recipe_draft.ingredient_count",
+        _count_items(recipe_payload.get("ingredients")),
+    )
+    span.set_attribute(
+        "recipe_draft.instruction_count",
+        _count_items(recipe_payload.get("instructions")),
+    )

--- a/apps/backend/src/services/ai/image_orchestrator.py
+++ b/apps/backend/src/services/ai/image_orchestrator.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from core.observability import get_tracer, set_span_error_status
 from models.users import User
 from services.ai.extraction_common import DraftManager
 from services.ai.interfaces import (
@@ -16,6 +17,9 @@ from services.ai.interfaces import (
     RecipeConverterProtocol,
 )
 from services.ai.models import DraftOutcome
+
+
+_tracer = get_tracer(__name__)
 
 
 class ImageOrchestrator(AIExtractionService):
@@ -47,58 +51,83 @@ class ImageOrchestrator(AIExtractionService):
         current_user: User,
         prompt_override: str | None = None,
     ) -> DraftOutcome[Any]:
-        try:
-            extraction_result = await self.ai_agent.run_image_extraction_agent(
-                normalized_images, prompt_override
+        with _tracer.start_as_current_span("ai_recipe_extract.image") as span:
+            span.set_attribute("ai_recipe.source_type", "image")
+            span.set_attribute("ai_recipe.streamed", False)
+            span.set_attribute("ai_recipe.image_count", len(normalized_images))
+            span.set_attribute(
+                "ai_recipe.prompt_override_used", prompt_override is not None
             )
-        except Exception as e:
-            from schemas.ai import ExtractionNotFound
+            try:
+                try:
+                    extraction_result = await self.ai_agent.run_image_extraction_agent(
+                        normalized_images, prompt_override
+                    )
+                except Exception as e:
+                    from schemas.ai import ExtractionNotFound
 
-            extraction_not_found = ExtractionNotFound(
-                reason=f"AI agent error: {str(e)}"
-            )
-            failure_draft = await self.draft_manager.create_failure_draft(
-                db=db,
-                current_user=current_user,
-                source_url="image_upload",
-                extraction_not_found=extraction_not_found,
-                prompt_override=prompt_override,
-            )
-            token = self.draft_manager.create_draft_token(
-                failure_draft.id, current_user.id, timedelta(hours=1)
-            )
-            return DraftOutcome(failure_draft, token, False, message="agent_error")
+                    span.set_attribute("ai_recipe.extraction_status", "agent_error")
+                    span.record_exception(e)
+                    set_span_error_status(span, e)
+                    extraction_not_found = ExtractionNotFound(
+                        reason=f"AI agent error: {str(e)}"
+                    )
+                    failure_draft = await self.draft_manager.create_failure_draft(
+                        db=db,
+                        current_user=current_user,
+                        source_url="image_upload",
+                        extraction_not_found=extraction_not_found,
+                        prompt_override=prompt_override,
+                    )
+                    token = self.draft_manager.create_draft_token(
+                        failure_draft.id, current_user.id, timedelta(hours=1)
+                    )
+                    span.set_attribute("ai_recipe.result_type", "failure_draft")
+                    return DraftOutcome(
+                        failure_draft, token, False, message="agent_error"
+                    )
 
-        from schemas.ai import ExtractionNotFound
+                from schemas.ai import ExtractionNotFound
 
-        if isinstance(extraction_result, ExtractionNotFound):
-            failure_draft = await self.draft_manager.create_failure_draft(
-                db=db,
-                current_user=current_user,
-                source_url="image_upload",
-                extraction_not_found=extraction_result,
-                prompt_override=prompt_override,
-            )
-            token = self.draft_manager.create_draft_token(
-                failure_draft.id, current_user.id, timedelta(hours=1)
-            )
-            return DraftOutcome(failure_draft, token, False, message="not_found")
+                if isinstance(extraction_result, ExtractionNotFound):
+                    failure_draft = await self.draft_manager.create_failure_draft(
+                        db=db,
+                        current_user=current_user,
+                        source_url="image_upload",
+                        extraction_not_found=extraction_result,
+                        prompt_override=prompt_override,
+                    )
+                    token = self.draft_manager.create_draft_token(
+                        failure_draft.id, current_user.id, timedelta(hours=1)
+                    )
+                    span.set_attribute("ai_recipe.extraction_status", "not_found")
+                    span.set_attribute("ai_recipe.result_type", "failure_draft")
+                    return DraftOutcome(
+                        failure_draft, token, False, message="not_found"
+                    )
 
-        generated_recipe = self.recipe_converter.convert_to_recipe_create(
-            extraction_result, "image_upload"
-        )
+                generated_recipe = self.recipe_converter.convert_to_recipe_create(
+                    extraction_result, "image_upload"
+                )
 
-        draft = await self.draft_manager.create_success_draft(
-            db=db,
-            current_user=current_user,
-            source_url="image_upload",
-            generated_recipe=generated_recipe,
-            prompt_override=prompt_override,
-        )
-        token = self.draft_manager.create_draft_token(
-            draft.id, current_user.id, timedelta(hours=1)
-        )
-        return DraftOutcome(draft, token, True)
+                draft = await self.draft_manager.create_success_draft(
+                    db=db,
+                    current_user=current_user,
+                    source_url="image_upload",
+                    generated_recipe=generated_recipe,
+                    prompt_override=prompt_override,
+                )
+                token = self.draft_manager.create_draft_token(
+                    draft.id, current_user.id, timedelta(hours=1)
+                )
+                span.set_attribute("ai_recipe.extraction_status", "success")
+                span.set_attribute("ai_recipe.result_type", "draft")
+                return DraftOutcome(draft, token, True)
+            except Exception as exc:
+                span.set_attribute("ai_recipe.extraction_status", "error")
+                span.record_exception(exc)
+                set_span_error_status(span, exc)
+                raise
 
     def stream_extraction_progress(
         self,
@@ -114,76 +143,103 @@ class ImageOrchestrator(AIExtractionService):
         # endpoint; this generator acts as a small replayer of stages and
         # verifies draft ownership when given a draft UUID as the
         # `source_url` parameter.
+        async def _gen() -> AsyncGenerator[str, None]:
+            with _tracer.start_as_current_span(
+                "ai_recipe_extract.image.stream"
+            ) as span:
+                span.set_attribute("ai_recipe.source_type", "image")
+                span.set_attribute("ai_recipe.streamed", True)
+                async for line in self._stream_image_progress(
+                    source_url, db, current_user, span
+                ):
+                    yield line
+
+        return _gen()
+
+    async def _stream_image_progress(
+        self,
+        source_url: str,
+        db: AsyncSession,
+        current_user: User,
+        span: Any,
+    ) -> AsyncGenerator[str, None]:
         from uuid import UUID
 
         from crud.ai_drafts import get_draft_by_id
         from schemas.ai import SSEEvent
 
-        async def _gen() -> AsyncGenerator[str, None]:
-            # Interpret source_url as draft id (UUID) for image streaming
-            try:
-                draft_uuid = UUID(str(source_url))
-            except Exception:
-                yield SSEEvent.terminal_error(
-                    step="auth",
-                    detail="Invalid draft id",
-                    error_code="invalid_draft",
-                ).to_sse()
-                return
-
-            # Fetch draft and verify ownership
-            draft = await get_draft_by_id(db, draft_uuid, None)
-            if not draft:
-                yield SSEEvent.terminal_error(
-                    step="fetch",
-                    detail="Draft not found",
-                    error_code="not_found",
-                ).to_sse()
-                return
-
-            draft_user_raw = getattr(draft, "user_id", None)
-            try:
-                draft_user_uuid = UUID(str(draft_user_raw))
-            except Exception:
-                yield SSEEvent.terminal_error(
-                    step="auth",
-                    detail="Draft owner ID is invalid",
-                    error_code="invalid_owner",
-                ).to_sse()
-                return
-
-            if draft_user_uuid != current_user.id:
-                yield SSEEvent.terminal_error(
-                    step="auth",
-                    detail="Draft does not belong to current user",
-                    error_code="unauthorized",
-                ).to_sse()
-                return
-
-            # Emit a small sequence of staged events. These are best-effort
-            # progress markers and do not reflect live AI tokens.
-            yield SSEEvent.model_validate(
-                {"status": "started", "step": "started", "progress": 0.0}
+        # Interpret source_url as draft id (UUID) for image streaming
+        try:
+            draft_uuid = UUID(str(source_url))
+        except Exception:
+            span.set_attribute("ai_recipe.extraction_status", "invalid_draft")
+            yield SSEEvent.terminal_error(
+                step="auth",
+                detail="Invalid draft id",
+                error_code="invalid_draft",
             ).to_sse()
+            return
 
-            yield SSEEvent.model_validate(
-                {"status": "processing", "step": "normalize", "progress": 0.1}
+        # Fetch draft and verify ownership
+        draft = await get_draft_by_id(db, draft_uuid, None)
+        if not draft:
+            span.set_attribute("ai_recipe.extraction_status", "not_found")
+            yield SSEEvent.terminal_error(
+                step="fetch",
+                detail="Draft not found",
+                error_code="not_found",
             ).to_sse()
+            return
 
-            yield SSEEvent.model_validate(
-                {"status": "ai_call", "step": "ai_call", "progress": 0.5}
+        draft_user_raw = getattr(draft, "user_id", None)
+        try:
+            draft_user_uuid = UUID(str(draft_user_raw))
+        except Exception:
+            span.set_attribute("ai_recipe.extraction_status", "invalid_owner")
+            yield SSEEvent.terminal_error(
+                step="auth",
+                detail="Draft owner ID is invalid",
+                error_code="invalid_owner",
             ).to_sse()
+            return
 
-            yield SSEEvent.model_validate(
-                {"status": "converting", "step": "convert_schema", "progress": 0.75}
+        if draft_user_uuid != current_user.id:
+            span.set_attribute("ai_recipe.extraction_status", "unauthorized")
+            yield SSEEvent.terminal_error(
+                step="auth",
+                detail="Draft does not belong to current user",
+                error_code="unauthorized",
             ).to_sse()
+            return
 
-            # Terminal event: success if payload exists on draft, failure otherwise
-            success = bool(getattr(draft, "payload", None))
-            yield (
-                SSEEvent.terminal_success(
-                    draft_id=str(draft_uuid), success=success
-                ).to_sse()
-            )
+        # Emit a small sequence of staged events. These are best-effort
+        # progress markers and do not reflect live AI tokens.
+        yield SSEEvent.model_validate(
+            {"status": "started", "step": "started", "progress": 0.0}
+        ).to_sse()
 
-        return _gen()
+        yield SSEEvent.model_validate(
+            {"status": "processing", "step": "normalize", "progress": 0.1}
+        ).to_sse()
+
+        yield SSEEvent.model_validate(
+            {"status": "ai_call", "step": "ai_call", "progress": 0.5}
+        ).to_sse()
+
+        yield SSEEvent.model_validate(
+            {"status": "converting", "step": "convert_schema", "progress": 0.75}
+        ).to_sse()
+
+        # Terminal event: success if payload exists on draft, failure otherwise
+        success = bool(getattr(draft, "payload", None))
+        span.set_attribute(
+            "ai_recipe.extraction_status", "success" if success else "not_found"
+        )
+        span.set_attribute(
+            "ai_recipe.result_type", "draft" if success else "failure_draft"
+        )
+        yield (
+            SSEEvent.terminal_success(
+                draft_id=str(draft_uuid), success=success
+            ).to_sse()
+        )

--- a/apps/backend/src/services/ai/url_orchestrator.py
+++ b/apps/backend/src/services/ai/url_orchestrator.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from core.observability import get_tracer, set_span_error_status
 from models.users import User
 from schemas.ai import SSEEvent
 from services.ai.extraction_common import DraftManager
@@ -18,6 +19,9 @@ from services.ai.interfaces import (
     RecipeConverterProtocol,
 )
 from services.ai.models import DraftOutcome
+
+
+_tracer = get_tracer(__name__)
 
 
 class UrlOrchestrator(AIExtractionService):
@@ -40,62 +44,87 @@ class UrlOrchestrator(AIExtractionService):
         current_user: User,
         prompt_override: str | None = None,
     ) -> DraftOutcome[Any]:
-        sanitized_html = await self.html_extractor.fetch_sanitized_html(source_url)
-        if not sanitized_html:
-            from schemas.ai import ExtractionNotFound
-
-            failure_draft = await self.draft_manager.create_failure_draft(
-                db=db,
-                current_user=current_user,
-                source_url=source_url,
-                extraction_not_found=ExtractionNotFound(reason="fetch_failed"),
-                prompt_override=prompt_override,
+        with _tracer.start_as_current_span("ai_recipe_extract.url") as span:
+            span.set_attribute("ai_recipe.source_type", "url")
+            span.set_attribute("ai_recipe.streamed", False)
+            span.set_attribute(
+                "ai_recipe.prompt_override_used", prompt_override is not None
             )
-            token = self.draft_manager.create_draft_token(
-                failure_draft.id,
-                current_user.id,
-                timedelta(hours=1),
-            )
-            return DraftOutcome(failure_draft, token, False, message="fetch_failed")
+            try:
+                sanitized_html = await self.html_extractor.fetch_sanitized_html(
+                    source_url
+                )
+                span.set_attribute("ai_recipe.html_found", bool(sanitized_html))
+                if not sanitized_html:
+                    from schemas.ai import ExtractionNotFound
 
-        extraction_result = await self.ai_agent.run_extraction_agent(
-            sanitized_html, prompt_override
-        )
+                    failure_draft = await self.draft_manager.create_failure_draft(
+                        db=db,
+                        current_user=current_user,
+                        source_url=source_url,
+                        extraction_not_found=ExtractionNotFound(reason="fetch_failed"),
+                        prompt_override=prompt_override,
+                    )
+                    token = self.draft_manager.create_draft_token(
+                        failure_draft.id,
+                        current_user.id,
+                        timedelta(hours=1),
+                    )
+                    span.set_attribute("ai_recipe.extraction_status", "fetch_failed")
+                    span.set_attribute("ai_recipe.result_type", "failure_draft")
+                    return DraftOutcome(
+                        failure_draft, token, False, message="fetch_failed"
+                    )
 
-        from schemas.ai import ExtractionNotFound
+                extraction_result = await self.ai_agent.run_extraction_agent(
+                    sanitized_html, prompt_override
+                )
 
-        if isinstance(extraction_result, ExtractionNotFound):
-            failure_draft = await self.draft_manager.create_failure_draft(
-                db=db,
-                current_user=current_user,
-                source_url=source_url,
-                extraction_not_found=extraction_result,
-                prompt_override=prompt_override,
-            )
-            token = self.draft_manager.create_draft_token(
-                failure_draft.id,
-                current_user.id,
-                timedelta(hours=1),
-            )
-            return DraftOutcome(failure_draft, token, False, message="not_found")
+                from schemas.ai import ExtractionNotFound
 
-        generated_recipe = self.recipe_converter.convert_to_recipe_create(
-            extraction_result, source_url
-        )
+                if isinstance(extraction_result, ExtractionNotFound):
+                    failure_draft = await self.draft_manager.create_failure_draft(
+                        db=db,
+                        current_user=current_user,
+                        source_url=source_url,
+                        extraction_not_found=extraction_result,
+                        prompt_override=prompt_override,
+                    )
+                    token = self.draft_manager.create_draft_token(
+                        failure_draft.id,
+                        current_user.id,
+                        timedelta(hours=1),
+                    )
+                    span.set_attribute("ai_recipe.extraction_status", "not_found")
+                    span.set_attribute("ai_recipe.result_type", "failure_draft")
+                    return DraftOutcome(
+                        failure_draft, token, False, message="not_found"
+                    )
 
-        draft = await self.draft_manager.create_success_draft(
-            db=db,
-            current_user=current_user,
-            source_url=source_url,
-            generated_recipe=generated_recipe,
-            prompt_override=prompt_override,
-        )
-        token = self.draft_manager.create_draft_token(
-            draft.id,
-            current_user.id,
-            timedelta(hours=1),
-        )
-        return DraftOutcome(draft, token, True)
+                generated_recipe = self.recipe_converter.convert_to_recipe_create(
+                    extraction_result, source_url
+                )
+
+                draft = await self.draft_manager.create_success_draft(
+                    db=db,
+                    current_user=current_user,
+                    source_url=source_url,
+                    generated_recipe=generated_recipe,
+                    prompt_override=prompt_override,
+                )
+                token = self.draft_manager.create_draft_token(
+                    draft.id,
+                    current_user.id,
+                    timedelta(hours=1),
+                )
+                span.set_attribute("ai_recipe.extraction_status", "success")
+                span.set_attribute("ai_recipe.result_type", "draft")
+                return DraftOutcome(draft, token, True)
+            except Exception as exc:
+                span.set_attribute("ai_recipe.extraction_status", "error")
+                span.record_exception(exc)
+                set_span_error_status(span, exc)
+                raise
 
     async def extract_recipe_from_images(
         self,
@@ -114,6 +143,25 @@ class UrlOrchestrator(AIExtractionService):
         current_user: User,
         prompt_override: str | None = None,
     ) -> AsyncGenerator[str, None]:
+        with _tracer.start_as_current_span("ai_recipe_extract.url") as span:
+            span.set_attribute("ai_recipe.source_type", "url")
+            span.set_attribute("ai_recipe.streamed", True)
+            span.set_attribute(
+                "ai_recipe.prompt_override_used", prompt_override is not None
+            )
+            async for line in self._stream_extraction_progress(
+                source_url, db, current_user, prompt_override, span
+            ):
+                yield line
+
+    async def _stream_extraction_progress(
+        self,
+        source_url: str,
+        db: AsyncSession,
+        current_user: User,
+        prompt_override: str | None,
+        span: Any,
+    ) -> AsyncGenerator[str, None]:
         yield (
             SSEEvent.model_validate(
                 {"status": "started", "step": "started", "progress": 0.0}
@@ -128,6 +176,9 @@ class UrlOrchestrator(AIExtractionService):
         try:
             html = await self.html_extractor.fetch_sanitized_html(source_url)
         except Exception as e:
+            span.set_attribute("ai_recipe.extraction_status", "fetch_failed")
+            span.record_exception(e)
+            set_span_error_status(span, e)
             yield (
                 SSEEvent.terminal_error(
                     step="fetch_html",
@@ -137,7 +188,9 @@ class UrlOrchestrator(AIExtractionService):
             )
             return
 
+        span.set_attribute("ai_recipe.html_found", bool(html))
         if not html:
+            span.set_attribute("ai_recipe.extraction_status", "empty_html")
             yield (
                 SSEEvent.terminal_error(
                     step="fetch_html",
@@ -163,6 +216,9 @@ class UrlOrchestrator(AIExtractionService):
                 html, prompt_override
             )
         except Exception as e:
+            span.set_attribute("ai_recipe.extraction_status", "agent_error")
+            span.record_exception(e)
+            set_span_error_status(span, e)
             yield (
                 SSEEvent.terminal_error(
                     step="ai_call",
@@ -184,6 +240,8 @@ class UrlOrchestrator(AIExtractionService):
             )
             # Commit the draft so it's available for immediate retrieval
             await db.commit()
+            span.set_attribute("ai_recipe.extraction_status", "not_found")
+            span.set_attribute("ai_recipe.result_type", "failure_draft")
             yield (
                 SSEEvent.terminal_success(
                     draft_id=getattr(draft_obj, "id", None), success=False
@@ -196,6 +254,9 @@ class UrlOrchestrator(AIExtractionService):
                 extraction_result, source_url
             )
         except Exception as e:
+            span.set_attribute("ai_recipe.extraction_status", "convert_failed")
+            span.record_exception(e)
+            set_span_error_status(span, e)
             yield (
                 SSEEvent.terminal_error(
                     step="convert_schema",
@@ -220,6 +281,8 @@ class UrlOrchestrator(AIExtractionService):
         )
         # Commit the draft so it's available for immediate retrieval
         await db.commit()
+        span.set_attribute("ai_recipe.extraction_status", "success")
+        span.set_attribute("ai_recipe.result_type", "draft")
         yield (
             SSEEvent.terminal_success(
                 draft_id=getattr(draft_obj, "id", None), success=True

--- a/apps/backend/src/services/chat_agent/tools/suggestions.py
+++ b/apps/backend/src/services/chat_agent/tools/suggestions.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pydantic_ai import RunContext
 
+from core.observability import get_tracer, set_span_error_status
 from core.security import create_draft_token
 from dependencies.db import AsyncSessionLocal
 from services.ai.draft_service import create_success_draft
@@ -14,6 +15,8 @@ from services.chat_agent.deps import ChatAgentDeps
 
 
 logger = logging.getLogger(__name__)
+
+_tracer = get_tracer(__name__)
 
 
 async def tool_suggest_recipe(
@@ -79,46 +82,65 @@ async def tool_suggest_recipe(
     if source_url:
         recipe_data["link_source"] = source_url
 
-    try:
-        # Use a separate database session for draft creation to avoid
-        # conflicts with concurrent tool executions (pydantic-ai runs
-        # multiple tools in parallel, which can cause session conflicts)
-        async with AsyncSessionLocal() as draft_db:
-            draft = await create_success_draft(
-                db=draft_db,
-                current_user=user,
-                source_url=source_url or "chat://recommendation",
-                generated_recipe=recipe_data,
+    with _tracer.start_as_current_span("recipe_draft.create") as span:
+        span.set_attribute("recipe_draft.has_title", bool(title))
+        span.set_attribute("recipe_draft.ingredient_count", len(ingredients))
+        span.set_attribute("recipe_draft.instruction_count", len(instructions))
+
+        try:
+            # Use a separate database session for draft creation to avoid
+            # conflicts with concurrent tool executions (pydantic-ai runs
+            # multiple tools in parallel, which can cause session conflicts)
+            async with AsyncSessionLocal() as draft_db:
+                draft = await create_success_draft(
+                    db=draft_db,
+                    current_user=user,
+                    source_url=source_url or "chat://recommendation",
+                    generated_recipe=recipe_data,
+                )
+                # Commit the draft in this separate session
+                await draft_db.commit()
+            span.set_attribute("draft_status", "created")
+
+            # Generate signed token for secure access
+            token = create_draft_token(draft_id=draft.id, user_id=user.id)
+            span.add_event(
+                "recipe_draft.token_created",
+                attributes={"recipe_draft.token_created": True},
             )
-            # Commit the draft in this separate session
-            await draft_db.commit()
 
-        # Generate signed token for secure access
-        token = create_draft_token(draft_id=draft.id, user_id=user.id)
+            # Build deep-link URL
+            deep_link = f"/recipes/new?ai=1&draftId={draft.id}&token={token}"
+            span.add_event(
+                "recipe_draft.deep_link_created",
+                attributes={"recipe_draft.deep_link_created": True},
+            )
+            span.set_attribute("result_type", "recipe_card")
 
-        # Build deep-link URL
-        deep_link = f"/recipes/new?ai=1&draftId={draft.id}&token={token}"
+            return {
+                "status": "ok",
+                "recipe_card": {
+                    "type": "recipe_card",
+                    "title": title,
+                    "subtitle": description,
+                    "image_url": None,
+                    "href": deep_link,
+                    "source_url": source_url,  # Original external URL for "View Recipe"
+                },
+                "message": (
+                    f"Created recipe draft for '{title}'. "
+                    "User can click 'Add Recipe' to save it."
+                ),
+            }
 
-        return {
-            "status": "ok",
-            "recipe_card": {
-                "type": "recipe_card",
-                "title": title,
-                "subtitle": description,
-                "image_url": None,
-                "href": deep_link,
-                "source_url": source_url,  # Original external URL for "View Recipe"
-            },
-            "message": (
-                f"Created recipe draft for '{title}'. "
-                "User can click 'Add Recipe' to save it."
-            ),
-        }
-
-    except Exception as e:
-        logger.error(f"Failed to create recipe draft: {e}")
-        return {
-            "status": "error",
-            "recipe_card": None,
-            "message": f"Failed to create recipe draft: {e!s}",
-        }
+        except Exception as exc:
+            span.set_attribute("draft_status", "error")
+            span.set_attribute("result_type", "error")
+            span.record_exception(exc)
+            set_span_error_status(span, exc)
+            logger.exception("Failed to create recipe draft")
+            return {
+                "status": "error",
+                "recipe_card": None,
+                "message": "Failed to create recipe draft. Please try again.",
+            }

--- a/apps/backend/tests/services/test_chat_agent_tools.py
+++ b/apps/backend/tests/services/test_chat_agent_tools.py
@@ -55,6 +55,74 @@ class MockRunContext:
         self.deps = deps or MockChatAgentDeps()
 
 
+class RecordingSpan:
+    """Minimal span double for recipe suggestion instrumentation tests."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.attributes: dict[str, object] = {}
+        self.events: list[tuple[str, dict[str, object] | None]] = []
+        self.exceptions: list[BaseException] = []
+        self.status: object | None = None
+
+    def __enter__(self) -> RecordingSpan:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+    def add_event(
+        self,
+        name: str,
+        attributes: dict[str, object] | None = None,
+    ) -> None:
+        self.events.append((name, attributes))
+
+    def record_exception(self, exception: BaseException) -> None:
+        self.exceptions.append(exception)
+
+    def set_status(self, status: object) -> None:
+        self.status = status
+
+
+class RecordingTracer:
+    """Minimal tracer double for recipe suggestion instrumentation tests."""
+
+    def __init__(self) -> None:
+        self.spans: list[RecordingSpan] = []
+
+    def start_as_current_span(self, name: str, **_kwargs: object) -> RecordingSpan:
+        span = RecordingSpan(name)
+        self.spans.append(span)
+        return span
+
+
+class FakeAsyncSession:
+    """Async session double used by AsyncSessionLocal tests."""
+
+    def __init__(self) -> None:
+        self.commits = 0
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+class FakeAsyncSessionLocal:
+    """Async context manager double for AsyncSessionLocal."""
+
+    def __init__(self, session: FakeAsyncSession) -> None:
+        self.session = session
+
+    async def __aenter__(self) -> FakeAsyncSession:
+        return self.session
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
 def _sample_recipe_params() -> dict[str, Any]:
     """Return sample recipe parameters for testing."""
     return {
@@ -75,6 +143,131 @@ def _sample_recipe_params() -> dict[str, Any]:
 
 class TestSuggestRecipeTool:
     """Tests for the suggest_recipe tool function."""
+
+    @pytest.mark.asyncio
+    async def test_suggest_recipe_records_safe_draft_span(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test successful recipe draft creation records safe business metadata."""
+        from services.chat_agent.tools import suggestions
+
+        params = _sample_recipe_params()
+        user = MockUser()
+        draft = MockDraft()
+        tracer = RecordingTracer()
+        fake_session = FakeAsyncSession()
+        token_value = "signed.jwt.token"
+
+        async def fake_create_success_draft(**_kwargs: object) -> MockDraft:
+            return draft
+
+        monkeypatch.setattr(suggestions, "_tracer", tracer)
+        monkeypatch.setattr(
+            suggestions,
+            "AsyncSessionLocal",
+            lambda: FakeAsyncSessionLocal(fake_session),
+        )
+        monkeypatch.setattr(
+            suggestions,
+            "create_success_draft",
+            fake_create_success_draft,
+        )
+        monkeypatch.setattr(
+            suggestions,
+            "create_draft_token",
+            lambda **_kwargs: token_value,
+        )
+
+        response = await suggestions.tool_suggest_recipe(
+            MockRunContext(MockChatAgentDeps(user=user)),
+            **params,
+        )
+
+        assert response["status"] == "ok"
+        assert response["recipe_card"]["type"] == "recipe_card"
+        assert response["recipe_card"]["href"].endswith(f"&token={token_value}")
+        assert fake_session.commits == 1
+
+        assert len(tracer.spans) == 1
+        span = tracer.spans[0]
+        assert span.name == "recipe_draft.create"
+        assert span.attributes == {
+            "recipe_draft.has_title": True,
+            "recipe_draft.ingredient_count": 2,
+            "recipe_draft.instruction_count": 3,
+            "draft_status": "created",
+            "result_type": "recipe_card",
+        }
+        assert span.events == [
+            (
+                "recipe_draft.token_created",
+                {"recipe_draft.token_created": True},
+            ),
+            (
+                "recipe_draft.deep_link_created",
+                {"recipe_draft.deep_link_created": True},
+            ),
+        ]
+        assert params["title"] not in str(span.attributes)
+        assert token_value not in str(span.attributes)
+        assert all(
+            token_value not in str(attributes) for _name, attributes in span.events
+        )
+
+    @pytest.mark.asyncio
+    async def test_suggest_recipe_records_exception_on_draft_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test draft failures are correlated without leaking internal details."""
+        from opentelemetry.trace import StatusCode
+
+        from services.chat_agent.tools import suggestions
+
+        params = _sample_recipe_params()
+        user = MockUser()
+        tracer = RecordingTracer()
+        fake_session = FakeAsyncSession()
+        failure = RuntimeError("database password leaked")
+
+        async def fake_create_success_draft(**_kwargs: object) -> MockDraft:
+            raise failure
+
+        monkeypatch.setattr(suggestions, "_tracer", tracer)
+        monkeypatch.setattr(
+            suggestions,
+            "AsyncSessionLocal",
+            lambda: FakeAsyncSessionLocal(fake_session),
+        )
+        monkeypatch.setattr(
+            suggestions,
+            "create_success_draft",
+            fake_create_success_draft,
+        )
+
+        response = await suggestions.tool_suggest_recipe(
+            MockRunContext(MockChatAgentDeps(user=user)),
+            **params,
+        )
+
+        assert response == {
+            "status": "error",
+            "recipe_card": None,
+            "message": "Failed to create recipe draft. Please try again.",
+        }
+
+        assert len(tracer.spans) == 1
+        span = tracer.spans[0]
+        assert span.name == "recipe_draft.create"
+        assert span.attributes["draft_status"] == "error"
+        assert span.attributes["result_type"] == "error"
+        assert span.exceptions == [failure]
+        assert span.status is not None
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.status.description == "RuntimeError"
+        assert "database password" not in str(response)
+        assert "database password" not in str(span.attributes)
 
     @pytest.mark.asyncio
     async def test_suggest_recipe_creates_draft_successfully(self) -> None:

--- a/apps/backend/tests/test_chat_streaming.py
+++ b/apps/backend/tests/test_chat_streaming.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextvars import ContextVar
+from types import SimpleNamespace
+from typing import cast
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -10,10 +14,101 @@ from fastapi import status
 from httpx import AsyncClient
 from pydantic_ai import models
 from pydantic_ai.models.test import TestModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from schemas.chat_streaming import ChatStreamRequest
 
 
 # Block any real model requests in tests
 models.ALLOW_MODEL_REQUESTS = False
+
+
+_current_span_name: ContextVar[str | None] = ContextVar(
+    "current_test_span_name",
+    default=None,
+)
+
+
+class _RecordingSpan:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.attributes: dict[str, object] = {}
+        self.events: list[tuple[str, dict[str, object] | None]] = []
+        self.exceptions: list[BaseException] = []
+        self._token: object | None = None
+
+    def __enter__(self) -> _RecordingSpan:
+        self._token = _current_span_name.set(self.name)
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        if self._token is not None:
+            _current_span_name.reset(self._token)
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+    def add_event(
+        self,
+        name: str,
+        attributes: dict[str, object] | None = None,
+    ) -> None:
+        self.events.append((name, attributes))
+
+    def record_exception(self, exception: BaseException) -> None:
+        self.exceptions.append(exception)
+
+
+class _RecordingTracer:
+    def __init__(self) -> None:
+        self.spans: list[_RecordingSpan] = []
+
+    def start_as_current_span(self, name: str, **_kwargs: object) -> _RecordingSpan:
+        span = _RecordingSpan(name)
+        self.spans.append(span)
+        return span
+
+
+class _SpanAwareAgent:
+    def __init__(self) -> None:
+        self.stream_span_name: str | None = None
+
+    async def run_stream_events(
+        self,
+        *_args: object,
+        **_kwargs: object,
+    ) -> AsyncIterator[object]:
+        self.stream_span_name = _current_span_name.get()
+        if False:
+            yield object()
+
+
+class _FakeResult:
+    def __init__(self, assistant_message: SimpleNamespace) -> None:
+        self._assistant_message = assistant_message
+
+    def scalar_one(self) -> SimpleNamespace:
+        return self._assistant_message
+
+
+class _FakeDb:
+    def __init__(self) -> None:
+        self.assistant_message = SimpleNamespace(
+            content_blocks=[],
+            message_metadata={"streaming": True},
+        )
+
+    def add(self, _obj: object) -> None:
+        return None
+
+    async def execute(self, _stmt: object) -> _FakeResult:
+        return _FakeResult(self.assistant_message)
+
+    async def commit(self) -> None:
+        return None
+
+    async def rollback(self) -> None:
+        return None
 
 
 @pytest.fixture
@@ -58,6 +153,73 @@ async def test_stream_chat_message_success(
 
     # Should have at least status, delta, and complete events
     assert len(events) >= 3
+
+
+@pytest.mark.asyncio
+async def test_agent_stream_runs_inside_assistant_span(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify Pydantic AI streaming starts while assistant_message is current."""
+    from api.v1 import chat
+
+    sensitive_prompt = "secret family recipe prompt should not become span metadata"
+    tracer = _RecordingTracer()
+    agent = _SpanAwareAgent()
+
+    async def _noop_async(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def _empty_history(*_args: object, **_kwargs: object) -> list[object]:
+        return []
+
+    class _FakeUserPreferencesCrud:
+        async def get_by_user_id(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+    class _FakeMemoryUpdateService:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def get_memory_document(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+    monkeypatch.setattr(chat, "_tracer", tracer)
+    monkeypatch.setattr(chat, "get_chat_agent", lambda: agent)
+    monkeypatch.setattr(chat, "get_correlation_id", lambda: "req-span-test")
+    monkeypatch.setattr(
+        chat,
+        "get_settings",
+        lambda: SimpleNamespace(LLM_PROVIDER="test-provider", CHAT_MODEL="test-model"),
+    )
+    monkeypatch.setattr(chat, "_get_or_create_conversation", _noop_async)
+    monkeypatch.setattr(chat, "_create_assistant_message", _noop_async)
+    monkeypatch.setattr(chat, "_update_conversation_activity", _noop_async)
+    monkeypatch.setattr(chat, "_load_conversation_history", _empty_history)
+    monkeypatch.setattr(chat, "UserPreferencesCRUD", _FakeUserPreferencesCrud)
+    monkeypatch.setattr(chat, "MemoryUpdateService", _FakeMemoryUpdateService)
+    monkeypatch.setattr(chat, "capture_training_sample", _noop_async)
+
+    response = await chat.stream_chat_message(
+        uuid4(),
+        ChatStreamRequest(content=sensitive_prompt),
+        SimpleNamespace(id=uuid4()),
+        cast(AsyncSession, _FakeDb()),
+    )
+
+    chunks: list[str] = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
+
+    assert agent.stream_span_name == "assistant_message"
+    assert any('"event":"message.complete"' in chunk for chunk in chunks)
+    assistant_spans = [
+        span for span in tracer.spans if span.name == "assistant_message"
+    ]
+    assert len(assistant_spans) == 1
+    assistant_span = assistant_spans[0]
+    assert assistant_span.attributes["product.telemetry.request_id"] == "req-span-test"
+    assert sensitive_prompt not in str(assistant_span.attributes)
+    assert all(sensitive_prompt not in str(event) for event in assistant_span.events)
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/test_chat_tool_stream_events.py
+++ b/apps/backend/tests/test_chat_tool_stream_events.py
@@ -12,6 +12,18 @@ from api.v1.chat import _handle_agent_stream_event, _ToolCallStart
 from models.chat_tool_calls import ChatToolCall
 
 
+class _FakeSpan:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object] | None]] = []
+
+    def add_event(
+        self,
+        name: str,
+        attributes: dict[str, object] | None = None,
+    ) -> None:
+        self.events.append((name, attributes))
+
+
 class _FakeDb:
     def __init__(self) -> None:
         self.added: list[object] = []
@@ -100,6 +112,76 @@ async def test_handle_agent_stream_event_emits_tool_started_and_result() -> None
     assert persisted[0].result == {"temp": 72}
     assert persisted[0].status == "success"
     assert db.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_stream_event_records_tool_lifecycle_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pydantic_ai.messages import (
+        FunctionToolCallEvent,
+        FunctionToolResultEvent,
+        ToolCallPart,
+        ToolReturnPart,
+    )
+
+    conversation_id = uuid4()
+    message_id = uuid4()
+    user_id = uuid4()
+    span = _FakeSpan()
+    db = _FakeDb()
+    tool_calls_by_id: dict[str, _ToolCallStart] = {}
+    tool_call_order = [0]
+
+    monkeypatch.setattr("api.v1.chat.get_current_span", lambda: span)
+
+    call_event = FunctionToolCallEvent(
+        ToolCallPart(
+            tool_name="get_daily_weather",
+            args={"zip": "12345"},
+            tool_call_id="call_1",
+        )
+    )
+    await _handle_agent_stream_event(
+        call_event,
+        conversation_id=conversation_id,
+        message_id=message_id,
+        user_id=user_id,
+        db=cast(AsyncSession, db),
+        tool_calls_by_id=tool_calls_by_id,
+        tool_call_order=tool_call_order,
+        request_id="req-1",
+    )
+
+    result_event = FunctionToolResultEvent(
+        ToolReturnPart(
+            tool_name="get_daily_weather",
+            content={"temp": 72},
+            tool_call_id="call_1",
+        )
+    )
+    await _handle_agent_stream_event(
+        result_event,
+        conversation_id=conversation_id,
+        message_id=message_id,
+        user_id=user_id,
+        db=cast(AsyncSession, db),
+        tool_calls_by_id=tool_calls_by_id,
+        tool_call_order=tool_call_order,
+        request_id="req-1",
+    )
+
+    assert [event_name for event_name, _attrs in span.events] == [
+        "assistant_tool_started",
+        "assistant_tool_completed",
+    ]
+    started_attrs = span.events[0][1] or {}
+    completed_attrs = span.events[1][1] or {}
+    assert started_attrs["product.telemetry.tool_names"] == "get_daily_weather"
+    assert completed_attrs["product.telemetry.success"] is True
+    assert "product.telemetry.latency_ms" in completed_attrs
+    assert "tool_call_id" not in started_attrs
+    assert "tool_call_id" not in completed_attrs
 
 
 def test_extract_tool_name_logs_warning_on_unknown(

--- a/apps/backend/tests/test_observability.py
+++ b/apps/backend/tests/test_observability.py
@@ -149,9 +149,8 @@ class TestConfigureObservability:
         mock_opentelemetry = MagicMock()
         mock_opentelemetry.trace = mock_trace
         mock_resource = MagicMock()
-        mock_resource.create.side_effect = (
-            lambda attrs: events.append(f"resource:{attrs['service.name']}")
-            or "resource"
+        mock_resource.create.side_effect = lambda attrs: (
+            events.append(f"resource:{attrs['service.name']}") or "resource"
         )
         mock_provider = MagicMock()
         mock_provider_cls = MagicMock(return_value=mock_provider)

--- a/apps/backend/tests/test_observability.py
+++ b/apps/backend/tests/test_observability.py
@@ -10,6 +10,7 @@ from core.observability import (
     ProductTelemetryEventName,
     _enable_pydantic_ai_instrumentation,
     _get_connection_string,
+    _is_console_trace_exporter_enabled,
     _is_observability_enabled,
     _NoOpSpan,
     _NoOpTracer,
@@ -73,6 +74,29 @@ class TestGetConnectionString:
         assert _get_connection_string() is None
 
 
+class TestConsoleTraceExporterEnabled:
+    """Tests for local console trace exporter selection."""
+
+    @pytest.mark.parametrize(
+        "env_value,expected",
+        [
+            ("console", True),
+            ("otlp,console", True),
+            ("CONSOLE", True),
+            ("otlp", False),
+            ("", False),
+        ],
+    )
+    def test_console_exporter_detection(
+        self,
+        env_value: str,
+        expected: bool,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("OTEL_TRACES_EXPORTER", env_value)
+        assert _is_console_trace_exporter_enabled() is expected
+
+
 class TestConfigureObservability:
     """Tests for configure_observability function."""
 
@@ -104,9 +128,71 @@ class TestConfigureObservability:
         """Test that False is returned when connection string is missing."""
         monkeypatch.setenv("ENABLE_OBSERVABILITY", "true")
         monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+        monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
         configure_observability.cache_clear()
         result = configure_observability()
         assert result is False
+
+    def test_configures_console_exporter_without_connection_string(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test local console exporter configures spans without Azure secrets."""
+        monkeypatch.setenv("ENABLE_OBSERVABILITY", "true")
+        monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "pantrypilot-backend-dev")
+        monkeypatch.setenv("OTEL_TRACES_EXPORTER", "console")
+        configure_observability.cache_clear()
+
+        events: list[str] = []
+        mock_trace = MagicMock()
+        mock_opentelemetry = MagicMock()
+        mock_opentelemetry.trace = mock_trace
+        mock_resource = MagicMock()
+        mock_resource.create.side_effect = (
+            lambda attrs: events.append(f"resource:{attrs['service.name']}")
+            or "resource"
+        )
+        mock_provider = MagicMock()
+        mock_provider_cls = MagicMock(return_value=mock_provider)
+        mock_exporter_cls = MagicMock(return_value="exporter")
+        mock_processor_cls = MagicMock(return_value="processor")
+        mock_instrumentor = MagicMock()
+        mock_instrumentor_cls = MagicMock(return_value=mock_instrumentor)
+        mock_agent = MagicMock()
+        mock_agent.instrument_all.side_effect = lambda: events.append("pydantic-ai")
+        mock_pydantic_ai = MagicMock()
+        mock_pydantic_ai.Agent = mock_agent
+
+        monkeypatch.setattr("core.observability._pydantic_ai_instrumented", False)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "opentelemetry": mock_opentelemetry,
+                "opentelemetry.sdk.resources": MagicMock(Resource=mock_resource),
+                "opentelemetry.sdk.trace": MagicMock(TracerProvider=mock_provider_cls),
+                "opentelemetry.sdk.trace.export": MagicMock(
+                    ConsoleSpanExporter=mock_exporter_cls,
+                    SimpleSpanProcessor=mock_processor_cls,
+                ),
+                "opentelemetry.instrumentation.fastapi": MagicMock(
+                    FastAPIInstrumentor=mock_instrumentor_cls
+                ),
+                "pydantic_ai": mock_pydantic_ai,
+            },
+        ):
+            result = configure_observability()
+
+        assert result is True
+        mock_provider_cls.assert_called_once_with(resource="resource")
+        mock_provider.add_span_processor.assert_called_once_with("processor")
+        mock_trace.set_tracer_provider.assert_called_once_with(mock_provider)
+        mock_instrumentor.instrument.assert_called_once_with(
+            excluded_urls="health,health/,favicon.ico"
+        )
+        mock_agent.instrument_all.assert_called_once_with()
+        assert events == ["resource:pantrypilot-backend-dev", "pydantic-ai"]
 
     def test_returns_false_on_import_error(
         self, monkeypatch: pytest.MonkeyPatch

--- a/apps/backend/tests/test_observability.py
+++ b/apps/backend/tests/test_observability.py
@@ -8,6 +8,7 @@ import pytest
 
 from core.observability import (
     ProductTelemetryEventName,
+    _enable_pydantic_ai_instrumentation,
     _get_connection_string,
     _is_observability_enabled,
     _NoOpSpan,
@@ -83,6 +84,20 @@ class TestConfigureObservability:
         result = configure_observability()
         assert result is False
 
+    def test_does_not_enable_pydantic_ai_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test disabled startup does not initialize Pydantic AI instrumentation."""
+        monkeypatch.setenv("ENABLE_OBSERVABILITY", "false")
+        configure_observability.cache_clear()
+
+        with patch(
+            "core.observability._enable_pydantic_ai_instrumentation"
+        ) as mock_enable:
+            result = configure_observability()
+            assert result is False
+            mock_enable.assert_not_called()
+
     def test_returns_false_when_no_connection_string(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -131,14 +146,63 @@ class TestConfigureObservability:
         configure_observability.cache_clear()
 
         # Mock the azure.monitor.opentelemetry module
+        events: list[str] = []
         mock_configure = MagicMock()
+        mock_configure.side_effect = lambda **_kwargs: events.append("azure")
         mock_module = MagicMock()
         mock_module.configure_azure_monitor = mock_configure
+        mock_agent = MagicMock()
+        mock_agent.instrument_all.side_effect = lambda: events.append("pydantic-ai")
+        mock_pydantic_ai = MagicMock()
+        mock_pydantic_ai.Agent = mock_agent
 
-        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": mock_module}):
+        monkeypatch.setattr("core.observability._pydantic_ai_instrumented", False)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": mock_module,
+                "pydantic_ai": mock_pydantic_ai,
+            },
+        ):
             result = configure_observability()
             assert result is True
             mock_configure.assert_called_once()
+            mock_agent.instrument_all.assert_called_once_with()
+            assert events == ["azure", "pydantic-ai"]
+
+    def test_returns_true_when_pydantic_ai_instrumentation_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test instrumentation failures are logged without failing startup."""
+        monkeypatch.setenv("ENABLE_OBSERVABILITY", "true")
+        monkeypatch.setenv(
+            "APPLICATIONINSIGHTS_CONNECTION_STRING",
+            "InstrumentationKey=test;IngestionEndpoint=https://test.com",
+        )
+        configure_observability.cache_clear()
+
+        mock_configure = MagicMock()
+        mock_module = MagicMock()
+        mock_module.configure_azure_monitor = mock_configure
+        mock_agent = MagicMock()
+        mock_agent.instrument_all.side_effect = RuntimeError("instrumentation failed")
+        mock_pydantic_ai = MagicMock()
+        mock_pydantic_ai.Agent = mock_agent
+
+        monkeypatch.setattr("core.observability._pydantic_ai_instrumented", False)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": mock_module,
+                "pydantic_ai": mock_pydantic_ai,
+            },
+        ):
+            result = configure_observability()
+            assert result is True
+            mock_configure.assert_called_once()
+            mock_agent.instrument_all.assert_called_once_with()
 
     def test_returns_false_on_configuration_exception(
         self, monkeypatch: pytest.MonkeyPatch
@@ -158,6 +222,25 @@ class TestConfigureObservability:
         with patch.dict("sys.modules", {"azure.monitor.opentelemetry": mock_module}):
             result = configure_observability()
             assert result is False
+
+
+class TestPydanticAiInstrumentation:
+    """Tests for Pydantic AI observability integration."""
+
+    def test_enable_pydantic_ai_instrumentation_is_idempotent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_agent = MagicMock()
+        mock_pydantic_ai = MagicMock()
+        mock_pydantic_ai.Agent = mock_agent
+
+        monkeypatch.setattr("core.observability._pydantic_ai_instrumented", False)
+
+        with patch.dict("sys.modules", {"pydantic_ai": mock_pydantic_ai}):
+            _enable_pydantic_ai_instrumentation()
+            _enable_pydantic_ai_instrumentation()
+
+        mock_agent.instrument_all.assert_called_once_with()
 
 
 class TestGetTracer:

--- a/docs/SECURITY_IMPLEMENTATION.md
+++ b/docs/SECURITY_IMPLEMENTATION.md
@@ -26,9 +26,9 @@ The chat assistant (Nibble) integrates with Azure Monitor via OpenTelemetry for 
 - Error types (not full error messages with user data)
 - Aggregated metrics (counts, latencies)
 
-### Logfire vs Azure Monitor
+### Local Trace Validation vs Azure Monitor
 
-- **Development**: Logfire can be used for local trace visualization
+- **Development**: Use the OpenTelemetry console exporter for no-secret local trace validation
 - **Production**: Azure Monitor Application Insights is the primary backend
 - **Important**: Logfire scrubbing only applies to structured fields, NOT span/log messages themselves
 
@@ -41,6 +41,49 @@ APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=...
 
 # Disable in local development (default)
 ENABLE_OBSERVABILITY=false
+
+# Validate traces locally without Azure credentials
+ENABLE_OBSERVABILITY=true
+OTEL_SERVICE_NAME=pantrypilot-backend-dev
+OTEL_TRACES_EXPORTER=console
+OTEL_TRACES_SAMPLER=always_on
+OTEL_PYTHON_LOG_CORRELATION=true
+```
+
+Run the backend locally with these settings, then exercise the authenticated chat
+stream endpoint. The backend console should show a single trace containing the
+FastAPI request span, `assistant_message`, native Pydantic AI agent/model/tool
+spans, and the `recipe_draft.create` business span when a suggested recipe draft
+is created.
+
+```bash
+cd apps/backend
+PYTHONPATH=./src uv run fastapi dev src/main.py --host 0.0.0.0 --port 8000
+curl http://localhost:8000/api/v1/health
+```
+
+When `APPLICATIONINSIGHTS_CONNECTION_STRING` is configured for a development
+Application Insights resource, verify operation linkage from Logs with KQL:
+
+```kusto
+requests
+| where url has "/api/v1/chat/conversations" and url has "/messages/stream"
+| order by timestamp desc
+| project timestamp, operation_Id, name, resultCode, duration
+```
+
+```kusto
+dependencies
+| where operation_Id == "<operation_Id>"
+| order by timestamp asc
+| project timestamp, id, operation_ParentId, name, type, target, success, duration
+```
+
+```kusto
+exceptions
+| where operation_Id == "<operation_Id>"
+| order by timestamp asc
+| project timestamp, operation_ParentId, type, outerMessage
 ```
 
 See `apps/backend/src/core/observability.py` for implementation details.


### PR DESCRIPTION
Adds backend OpenTelemetry tracing improvements so chat requests can be validated locally and in Application Insights with nested FastAPI, assistant, Pydantic AI, tool, and recipe draft spans.

Summary:
- enable guarded Pydantic AI OpenTelemetry instrumentation after observability setup
- keep chat streaming inside the active assistant span and retain low-cardinality tool lifecycle events
- add safe recipe draft business spans, exception recording, and local console-export validation docs

Validation:
- `uv run pytest tests/test_observability.py tests/test_chat_streaming.py tests/test_chat_tool_stream_events.py tests/services/test_chat_agent_tools.py -q`
- `make lint-backend`
- `make type-check-backend`
- `uv run pytest -q`
- local console exporter smoke check for nested `assistant_message` -> `recipe_draft.create` spans

Live authenticated chat-stream and Application Insights verification are documented but were not executed in this session because no bearer token or development Application Insights connection string was available.

Fixes #531